### PR TITLE
Remove toDateTime64 casting

### DIFF
--- a/spec/sql_query_specs.jest.ts
+++ b/spec/sql_query_specs.jest.ts
@@ -15,7 +15,7 @@ describe("Query SELECT with $timeFilterByColumn and range with from and to:", ()
         expect(SqlQuery.replaceTimeFilters(query, range, 'DATETIME'))
             .toBe('SELECT * FROM table WHERE column_name >= toDateTime(1545613323) AND column_name <= toDateTime(1546300799)');
         expect(SqlQuery.replaceTimeFilters(query, range, 'DATETIME64'))
-            .toBe('SELECT * FROM table WHERE toDateTime64(column_name, 3) >= toDateTime64(1545613323, 3) AND toDateTime64(column_name, 3) <= toDateTime64(1546300799, 3)');
+            .toBe('SELECT * FROM table WHERE column_name >= toDateTime64(1545613323, 3) AND column_name <= toDateTime64(1546300799, 3)');
     });
 });
 
@@ -40,8 +40,8 @@ describe("Query SELECT with $timeFilterByColumn and range with from", () => {
         expect(SqlQuery.replaceTimeFilters(query, range, 'DATETIME64'))
             .toBe(
                 'SELECT * FROM table WHERE ' +
-                'toDateTime64(column_name, 3) >= toDateTime64(' + range.from.unix() + ', 3) AND ' +
-                'toDateTime64(column_name, 3) <= toDateTime64(' + range.to.unix() + ', 3)'
+                'column_name >= toDateTime64(' + range.from.unix() + ', 3) AND ' +
+                'column_name <= toDateTime64(' + range.to.unix() + ', 3)'
             );
     });
 });
@@ -55,7 +55,7 @@ describe("Query SELECT with $timeSeries $timeFilter and DATETIME64", () => {
         "ORDER BY t";
     const expQuery = "SELECT (intDiv(toFloat64(\"d\") * 1000, (15 * 1000)) * (15 * 1000)) as t, sum(x) AS metric\n" +
         "FROM default.test_datetime64\n" +
-        "WHERE toDateTime64(\"d\", 3) >= toDateTime64(1545613320, 3) AND toDateTime64(\"d\", 3) <= toDateTime64(1546300740, 3)\n" +
+        "WHERE \"d\" >= toDateTime64(1545613320, 3) AND \"d\" <= toDateTime64(1546300740, 3)\n" +
         "GROUP BY t\n" +
         "ORDER BY t";
     let templateSrv = new TemplateSrvStub();

--- a/src/sql_query.ts
+++ b/src/sql_query.ts
@@ -170,12 +170,6 @@ export default class SqlQuery {
 
     static getFilterSqlForDateTime(columnName: string, dateTimeType: string) {
         const convertFn = this.getConvertFn(dateTimeType);
-
-        /* @TODO remove IF when resolve https://github.com/ClickHouse/ClickHouse/issues/16655 */
-        if (dateTimeType === "DATETIME64") {
-            return `${convertFn(columnName)} >= ${convertFn('$from')} AND ${convertFn(columnName)} <= ${convertFn('$to')}`;
-        }
-
         return `${columnName} >= ${convertFn('$from')} AND ${columnName} <= ${convertFn('$to')}`;
     }
 
@@ -483,12 +477,6 @@ export default class SqlQuery {
             }
             return t;
         };
-
-        /* @TODO remove IF statement after resolve https://github.com/ClickHouse/ClickHouse/issues/16655 */
-        if (dateTimeType === 'DATETIME64') {
-            return convertFn('$dateTimeCol') + ' >= ' + convertFn('$from') + ' AND ' +
-                   convertFn('$dateTimeCol') + ' <= ' + convertFn('$to');
-        }
         return '$dateTimeCol >= ' + convertFn('$from') + ' AND $dateTimeCol <= ' + convertFn('$to');
     }
 


### PR DESCRIPTION
Remove toDateTime64 casting for column when time column is already DateTime64 to improve performance.
Change test to ensure the casting is removed from the query