### PR TITLE
toTable: format value

### DIFF
--- a/src/sql_series.ts
+++ b/src/sql_series.ts
@@ -33,7 +33,7 @@ export default class SqlSeries {
         each(self.series, function (ser) {
             let r = [];
             each(columns, function (col) {
-                r.push(ser[col.text]);
+                r.push(SqlSeries._formatValue(ser[col.text]));
             });
             rows.push(r);
         });


### PR DESCRIPTION
fix mismatch between type in columns and values in rows.

In grafana, legacy table conversion to DataFrame does not cast the values with the specified type so panels like Bar Charts were broken with clickhouse datasource.

