### PR TITLE
Adhoc filter: Fixed when key contains dot #416

### DIFF
--- a/src/sql_query.ts
+++ b/src/sql_query.ts
@@ -57,7 +57,13 @@ export default class SqlQuery {
                 let target = SqlQuery.target(ast.from[0], this.target);
 
                 adhocFilters.forEach(function (af) {
-                    let parts = af.key.split('.');
+                    let parts;
+                    let partsKey = af.key;
+                    if (partsKey.includes('.')) {
+                        parts = [target[0], target[1], partsKey];
+                    } else {
+                        parts = af.key.split('.');
+                    }
                     /* Wildcard table, substitute current target table */
                     if (parts.length === 1) {
                         parts.unshift(target[1]);


### PR DESCRIPTION
Fixes #415.
This change solves the problem of filtering with an adhoc filter when the key contains a dot.
As for the tests to which this change applies, they are in clickhouse-grafana / spec / sql_query_specs.jest.ts and both tests related to this change fail, all other tests pass successfully. 
I did not write new tests, but certain existing tests fall from the specified file (sql_query_specs.jest.ts).
Perhaps these tests could be adapted to accept this change.
