### PR TITLE
Fix multi-dimensional alert when label dimension > 1

### DIFF
--- a/pkg/response.go
+++ b/pkg/response.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -176,10 +177,15 @@ func (r *Response) createFrameIfNotExistsAndAddPoint(query *Query, framesMap map
 
 func (r *Response) generateFrameNameByLabels(row map[string]interface{}, metaTypes map[string]string, labelFieldsMap map[string]int) string {
 	frameName := ""
-	for fieldName, fieldValue := range row {
+	srow := make([]string, 0, len(row))
+	for k := range row {
+		srow = append(srow, k)
+	}
+	sort.Strings(srow)
+	for _, fieldName := range srow {
 		if _, isLabel := labelFieldsMap[fieldName]; isLabel {
 			fieldType := metaTypes[fieldName]
-			frameName += fmt.Sprintf("%v", ParseValue(fieldName, fieldType, nil, fieldValue, false)) + ", "
+			frameName += fmt.Sprintf("%v", ParseValue(fieldName, fieldType, nil, row[fieldName], false)) + ", "
 		}
 	}
 	if frameName != "" {


### PR DESCRIPTION
Try to fix #417 . All comments/expected behaviour are described on the issue.

Didn't want to change/break so much, so the PR is simple as sort the row map keys to guarantee the order when the label is generated