### PR TITLE
fix($conditionalTest): preserve commas inside SQL_if (quotes + \, escape)

### DIFF
--- a/src/datasource/helpers/index.test.ts
+++ b/src/datasource/helpers/index.test.ts
@@ -1013,4 +1013,130 @@ describe('conditionalTest', () => {
       expect(result).not.toContain("AND host = '$host'");
     });
   });
+
+  describe('2-parameter format with comma inside SQL_if (leading-comma idiom)', () => {
+    it('should keep the leading comma when variable has a value', () => {
+      const query = 'SELECT t, key FROM table GROUP BY t, key $conditionalTest(, ${group_by_trend:raw}, $group_by_trend)';
+      const templateSrv = createTemplateSrv([
+        { name: 'group_by_trend', type: 'query', current: { value: 'category' } },
+      ]);
+      const result = conditionalTest(query, templateSrv as any);
+      expect(result).toContain(', ${group_by_trend:raw}');
+      expect(result).not.toContain('$conditionalTest');
+    });
+
+    it('should remove the whole expression (including comma) when variable is $__all', () => {
+      const query = 'SELECT t, key FROM table GROUP BY t, key $conditionalTest(, ${group_by_trend:raw}, $group_by_trend)';
+      const templateSrv = createTemplateSrv([
+        { name: 'group_by_trend', type: 'query', current: { value: '$__all' } },
+      ]);
+      const result = conditionalTest(query, templateSrv as any);
+      expect(result).not.toContain('group_by_trend');
+      expect(result).not.toContain('$conditionalTest');
+    });
+
+    it('should keep the trailing comma when variable has a value (EXPR,, $var idiom)', () => {
+      const query = 'SELECT $conditionalTest(category,, $trend) other FROM table';
+      const templateSrv = createTemplateSrv([
+        { name: 'trend', type: 'query', current: { value: 'on' } },
+      ]);
+      const result = conditionalTest(query, templateSrv as any);
+      expect(result).toContain('category,');
+      expect(result).not.toContain('$conditionalTest');
+    });
+
+    it('should remove the whole expression (including trailing comma) when variable is empty', () => {
+      const query = 'SELECT $conditionalTest(category,, $trend) other FROM table';
+      const templateSrv = createTemplateSrv([
+        { name: 'trend', type: 'query', current: { value: [] } },
+      ]);
+      const result = conditionalTest(query, templateSrv as any);
+      expect(result).not.toContain('category');
+      expect(result).not.toContain('$conditionalTest');
+    });
+
+    it('should treat 2 commas with both branches non-empty as genuine 3-param', () => {
+      const query = "SELECT * FROM table WHERE $timeFilter $conditionalTest(AND a IN ($v), AND 1=1, $v)";
+      const templateSrv = createTemplateSrv([
+        { name: 'v', type: 'query', current: { value: '$__all' } },
+      ]);
+      const result = conditionalTest(query, templateSrv as any);
+      expect(result).toContain('AND 1=1');
+      expect(result).not.toContain('AND a IN ($v)');
+    });
+  });
+
+  describe('escaped commas (\\,) inside SQL_if', () => {
+    it('should force 2-param parsing and emit a literal comma when value is present', () => {
+      // Without the escape this would parse as 3-param (both branches non-empty)
+      const query = 'SELECT * FROM table GROUP BY t $conditionalTest(category\\, trend, $group_by)';
+      const templateSrv = createTemplateSrv([
+        { name: 'group_by', type: 'query', current: { value: 'something' } },
+      ]);
+      const result = conditionalTest(query, templateSrv as any);
+      expect(result).toContain('category, trend');
+      expect(result).not.toContain('\\,');
+      expect(result).not.toContain('$conditionalTest');
+    });
+
+    it('should keep an escaped leading comma in the 3-param SQL_if branch', () => {
+      const query = "SELECT * FROM table $conditionalTest(\\, a, AND b=2, $v)";
+      const templateSrv = createTemplateSrv([
+        { name: 'v', type: 'query', current: { value: 'x' } },
+      ]);
+      const result = conditionalTest(query, templateSrv as any);
+      expect(result).toContain(', a');
+      expect(result).not.toContain('\\,');
+      expect(result).not.toContain('AND b=2');
+    });
+
+    it('should remove the macro (escaped comma included) when value is empty', () => {
+      const query = 'SELECT * FROM table GROUP BY t $conditionalTest(category\\, trend, $group_by)';
+      const templateSrv = createTemplateSrv([
+        { name: 'group_by', type: 'query', current: { value: [] } },
+      ]);
+      const result = conditionalTest(query, templateSrv as any);
+      expect(result).not.toContain('category');
+      expect(result).not.toContain('$conditionalTest');
+    });
+  });
+
+  describe('commas inside string literals are not argument separators', () => {
+    it('should keep a comma inside a single-quoted string in SQL_if', () => {
+      const query = "SELECT $conditionalTest(AND t = 'red,blue', $v) c FROM table";
+      const templateSrv = createTemplateSrv([{ name: 'v', type: 'query', current: { value: 'x' } }]);
+      const result = conditionalTest(query, templateSrv as any);
+      expect(result).toContain("AND t = 'red,blue'");
+      expect(result).not.toContain('$conditionalTest');
+    });
+
+    it('should keep a comma inside a double-quoted string in SQL_if', () => {
+      const query = 'SELECT $conditionalTest(AND t = "a,b", $v) c FROM table';
+      const templateSrv = createTemplateSrv([{ name: 'v', type: 'query', current: { value: 'x' } }]);
+      const result = conditionalTest(query, templateSrv as any);
+      expect(result).toContain('AND t = "a,b"');
+    });
+
+    it('should keep a comma inside a backtick-quoted identifier', () => {
+      const query = 'SELECT $conditionalTest(AND `c,x` = 1, $v) c FROM table';
+      const templateSrv = createTemplateSrv([{ name: 'v', type: 'query', current: { value: 'x' } }]);
+      const result = conditionalTest(query, templateSrv as any);
+      expect(result).toContain('`c,x`');
+    });
+
+    it('should not count an escaped quote as a string boundary', () => {
+      const query = "SELECT $conditionalTest(AND t = 'it\\'s,ok', $v) c FROM table";
+      const templateSrv = createTemplateSrv([{ name: 'v', type: 'query', current: { value: 'x' } }]);
+      const result = conditionalTest(query, templateSrv as any);
+      expect(result).toContain("AND t = 'it\\'s,ok'");
+    });
+
+    it('should ignore quoted commas when picking 3-param branches', () => {
+      const query = "WHERE $conditionalTest(AND t IN ('a,b'), AND 1=1, $v)";
+      const templateSrv = createTemplateSrv([{ name: 'v', type: 'query', current: { value: [] } }]);
+      const result = conditionalTest(query, templateSrv as any);
+      expect(result).toContain('AND 1=1');
+      expect(result).not.toContain("AND t IN ('a,b')");
+    });
+  });
 });

--- a/src/datasource/helpers/index.ts
+++ b/src/datasource/helpers/index.ts
@@ -36,43 +36,52 @@ export const conditionalTest = (query: string, templateSrv: TemplateSrv) => {
     }
     let arg = r.result;
 
-    // Count commas outside of nested parentheses to detect 2-param vs 3-param format
-    let commaCount = 0;
+    // Collect positions of argument-separator commas: top-level commas that are outside any
+    // nested parentheses AND outside any string literal. Commas inside '...', "..." or `...`
+    // and commas escaped as '\,' belong to the SQL text, not the macro arguments. A backslash
+    // escapes the next character (so '\,' is a literal comma and '\'' is an escaped quote).
+    let topCommas: number[] = [];
     let nestedParentheses = 0;
+    let quote = '';
     for (let i = 0; i < arg.length; i++) {
-      if (arg[i] === '(') {
+      const ch = arg[i];
+      if (ch === '\\') {
+        i++; // skip the escaped character
+      } else if (quote) {
+        if (ch === quote) {
+          quote = '';
+        }
+      } else if (ch === "'" || ch === '"' || ch === '`') {
+        quote = ch;
+      } else if (ch === '(') {
         nestedParentheses++;
-      } else if (arg[i] === ')') {
+      } else if (ch === ')') {
         nestedParentheses--;
-      } else if (arg[i] === ',' && nestedParentheses === 0) {
-        commaCount++;
+      } else if (ch === ',' && nestedParentheses === 0) {
+        topCommas.push(i);
       }
     }
+    const unescapeCommas = (s: string) => s.replace(/\\,/g, ',');
+
+    let firstCommaPos = topCommas.length > 0 ? topCommas[0] : -1;
+    let secondCommaPos = topCommas.length > 1 ? topCommas[1] : -1;
+
+    // A genuine 3-parameter form $conditionalTest(SQL_if, SQL_else, $var) has BOTH branches
+    // non-empty. The 2-param idioms carry a comma inside SQL_if, which leaves one segment empty:
+    //   - leading-comma:  $conditionalTest(, ${group_by_trend:raw}, $group_by_trend)  -> empty first
+    //   - trailing-comma: $conditionalTest(category,, $trend)               -> empty middle
+    // In both cases the comma belongs to SQL_if, so keep them as 2-param (handled via the last
+    // separator comma below). An empty SQL_else in a 3-param form would just duplicate the 2-param
+    // behaviour anyway. For full control, escape the comma as '\,' to force it into the SQL text.
+    const isThreeParam =
+      topCommas.length === 2 &&
+      arg.substring(0, firstCommaPos).trim().length > 0 &&
+      arg.substring(firstCommaPos + 1, secondCommaPos).trim().length > 0;
 
     // For 3-parameter format: $conditionalTest(SQL_if, SQL_else, $var)
-    if (commaCount === 2) {
-      // Find positions of commas that aren't inside nested parentheses
-      let firstCommaPos = -1;
-      let secondCommaPos = -1;
-      nestedParentheses = 0;
-
-      for (let i = 0; i < arg.length; i++) {
-        if (arg[i] === '(') {
-          nestedParentheses++;
-        } else if (arg[i] === ')') {
-          nestedParentheses--;
-        } else if (arg[i] === ',' && nestedParentheses === 0) {
-          if (firstCommaPos === -1) {
-            firstCommaPos = i;
-          } else {
-            secondCommaPos = i;
-            break;
-          }
-        }
-      }
-
-      let sqlIf = arg.substring(0, firstCommaPos).trim();
-      let sqlElse = arg.substring(firstCommaPos + 1, secondCommaPos).trim();
+    if (isThreeParam) {
+      let sqlIf = unescapeCommas(arg.substring(0, firstCommaPos).trim());
+      let sqlElse = unescapeCommas(arg.substring(firstCommaPos + 1, secondCommaPos).trim());
       let varParam = arg.substring(secondCommaPos + 1).trim();
 
       if (!varParam.startsWith('$')) {
@@ -115,9 +124,11 @@ export const conditionalTest = (query: string, templateSrv: TemplateSrv) => {
     // For 2-parameter format: $conditionalTest(SQL_if, $var)
     else {
       // first parameters is an expression and require some complex parsing,
-      // so parse from the end where you know that the last parameters is a comma with a variable
-      let param1 = arg.substring(0, arg.lastIndexOf(',')).trim();
-      let param2 = arg.substring(arg.lastIndexOf(',') + 1).trim();
+      // so parse from the end where you know that the last parameters is a comma with a variable.
+      // Split on the last separator comma (top-level, unescaped); any '\,' stays inside SQL_if.
+      let splitPos = topCommas.length > 0 ? topCommas[topCommas.length - 1] : arg.lastIndexOf(',');
+      let param1 = unescapeCommas(arg.substring(0, splitPos).trim());
+      let param2 = arg.substring(splitPos + 1).trim();
       // remove the $ from the variable
       let varInParam = param2.substring(1);
       let done = 0;

--- a/src/views/QueryEditor/components/QueryTextEditor/editor/autocompletions/macros.ts
+++ b/src/views/QueryEditor/components/QueryTextEditor/editor/autocompletions/macros.ts
@@ -205,6 +205,8 @@ const getMacrosAutocompletion = function () {
       docText:
         'Will add `SQL predicate` filter expression only if $variable have non empty value. ' +
         'Alternatively, can use the format with 3 parameters where SQL_else is used when $variable is empty. ' +
+        'To include a literal comma inside an SQL argument (so it is not treated as an argument ' +
+        'separator), escape it as `\\,` — e.g. $conditionalTest(category\\, trend, $group_by). ' +
         '\n' +
         'Example:\n' +
         'SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter\n' +


### PR DESCRIPTION
The [new conditionalTest 3-parameter format](https://github.com/Altinity/clickhouse-grafana/pull/726) caused some existing queries to break where a comma was a part of the first parameter value. These are somewhat common if we extend GROUP BY or ORDER BY lists with a `conditionalTest` macro: Often there is a need to have a leading comma in the string that conditionalTest produces.

Furthermore it would be good IMO to disambiguate if a comma is a delimiter or part of a string properly so there should also be a "proper" form where the commas are escaped.   

The 2- vs 3-parameter form of $conditionalTest was decided purely by counting top-level commas, and the comma scan only skipped commas inside parentheses. Any 2-parameter macro whose SQL_if contained a comma was therefore misparsed and the comma dropped, producing broken SQL. Affected cases:

  - leading-comma idiom:   $conditionalTest(, expr, $var)
  - trailing-comma idiom:  $conditionalTest(expr,, $var)
  - a comma inside a string literal, e.g. AND t = 'a,b', was treated as an
    argument separator and truncated the query.

Fix which maintains the compatibility with the existing style and also provides a better, escaped format:
  - Treat a 2-comma macro as 3-parameter only when BOTH branches are non-empty; an empty first/middle segment means the comma belongs to SQL_if.
  - Make the comma scan quote-aware ('...', "...", `...`) and backslash-aware, so commas inside string literals are never treated as separators.
  - Add `\,` as an explicit escape for a literal comma in SQL_if.
  - Document the `\,` escape in the macro autocomplete tooltip.

Adds regression tests for the leading/trailing-comma idioms, the 3-parameter form, quoted commas (single/double/backtick), escaped quotes, and `\,` escaping.