### PR TITLE
parse ClickHouse JSON responses losslessly to preserve 64-bit integers precision

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@grafana/ui": "13.1.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
+        "lossless-json": "^4.3.0",
         "luxon": "^3.7.2",
         "pako": "^2.1.0",
         "react": "19.2.4",
@@ -12301,6 +12302,12 @@
       "bin": {
         "loose-envify": "cli.js"
       }
+    },
+    "node_modules/lossless-json": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-4.3.0.tgz",
+      "integrity": "sha512-ToxOC+SsduRmdSuoLZLYAr5zy1Qu7l5XhmPWM3zefCZ5IcrzW/h108qbJUKfOlDlhvhjUK84+8PSVX0kxnit0g==",
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@grafana/ui": "13.1.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
+    "lossless-json": "^4.3.0",
     "luxon": "^3.7.2",
     "pako": "^2.1.0",
     "react": "19.2.4",

--- a/src/datasource/datasource.request.test.ts
+++ b/src/datasource/datasource.request.test.ts
@@ -1,0 +1,26 @@
+jest.mock('@grafana/runtime', () => ({
+  getBackendSrv: jest.fn(),
+  getTemplateSrv: jest.fn(),
+  getGrafanaLiveSrv: jest.fn(),
+  config: { bootData: { user: { login: '' } } },
+  DataSourceWithBackend: class {},
+}));
+jest.mock('../views/QueryEditor/QueryEditor', () => ({
+  QueryEditor: () => null,
+}));
+
+import { CHDataSource } from './datasource';
+
+describe('CHDataSource._getRequestOptions', () => {
+  const options = { url: 'http://localhost:8123' };
+
+  it('requests the response as raw text so large integers survive parsing (issue #832)', () => {
+    const requestOptions = CHDataSource._getRequestOptions('SELECT 1 FORMAT JSON', true, 'req-1', options);
+    expect(requestOptions.responseType).toBe('text');
+  });
+
+  it('requests raw text for GET requests as well', () => {
+    const requestOptions = CHDataSource._getRequestOptions('SELECT 1 FORMAT JSON', false, 'req-2', options);
+    expect(requestOptions.responseType).toBe('text');
+  });
+});

--- a/src/datasource/datasource.ts
+++ b/src/datasource/datasource.ts
@@ -25,6 +25,7 @@ import { getAdhocFilters } from '../views/QueryEditor/helpers/getAdHocFilters';
 import { from, merge, Observable } from 'rxjs';
 import { adhocFilterVariable, conditionalTest, convertTimestamp, createContextAwareInterpolation } from './helpers';
 import { ClickHouseResourceClient } from './resource_handler';
+import { parseJsonResponseLossless, tryParseJson } from './losslessJson';
 import { generateQueryForTimestampBackward, generateQueryForTimestampForward } from './log-context-query';
 import { IndexedDBManager } from '../utils/indexedDBManager';
 
@@ -143,6 +144,11 @@ export class CHDataSource
     let requestOptions: any = {
       url: options.url,
       requestId: requestId,
+      // Fetch the body as raw text: Grafana's own JSON.parse would round
+      // 64-bit integers above 2^53-1 before the plugin ever sees them.
+      // Parsing is done losslessly in _request/annotationQuery instead.
+      // https://github.com/Altinity/clickhouse-grafana/issues/832
+      responseType: 'text',
     };
     let params: string[] = [];
 
@@ -153,8 +159,6 @@ export class CHDataSource
       requestOptions.method = 'GET';
       params.push('query=' + encodeURIComponent(query));
     }
-    // https://github.com/Altinity/clickhouse-grafana/issues/832, https://github.com/ClickHouse/ClickHouse/issues/86553
-    // params.push('output_format_json_quote_64bit_integers=1');
     if (options.defaultDatabase) {
       params.push('database=' + options.defaultDatabase);
     }
@@ -210,15 +214,27 @@ export class CHDataSource
       this.backendSrv.fetch(queryParams).subscribe(
         (response) => {
           if (response && response?.data) {
-            resolve(response.data);
+            try {
+              resolve(parseJsonResponseLossless(response.data));
+            } catch (parseError) {
+              reject({
+                originalError: parseError,
+                query: query,
+                requestId: requestId,
+              });
+            }
           } else {
             resolve(null);
           }
         },
         (error) => {
-          // Enhance error with more context information
+          // Enhance error with more context information.
+          // With responseType 'text' the error body arrives as a raw string;
+          // restore the parsed object shape that downstream classification
+          // (e.g. isPermissionError reading error.data.exception) relies on.
           const enhancedError = {
             ...error,
+            data: tryParseJson(error?.data),
             originalError: error,
             query: query,
             requestId: requestId
@@ -832,10 +848,15 @@ export class CHDataSource
     const dataRequest = new Promise((resolve, reject) => {
       this.backendSrv.fetch(queryParams).subscribe(
         (response) => {
-          resolve(this.responseParser.transformAnnotationResponse(params, response.data) as AnnotationEvent[]);
+          try {
+            const data = parseJsonResponseLossless(response.data);
+            resolve(this.responseParser.transformAnnotationResponse(params, data) as AnnotationEvent[]);
+          } catch (parseError) {
+            reject(parseError);
+          }
         },
         (e) => {
-          reject(e);
+          reject({ ...e, data: tryParseJson(e?.data) });
         }
       );
     });

--- a/src/datasource/losslessJson.test.ts
+++ b/src/datasource/losslessJson.test.ts
@@ -1,0 +1,150 @@
+import { parseJsonResponseLossless, tryParseJson } from './losslessJson';
+import SqlSeries from './sql-series/sql_series';
+
+describe('parseJsonResponseLossless', () => {
+  it('preserves an unsafe UInt64 value as a string (issue #832 reproduction)', () => {
+    expect(parseJsonResponseLossless('{"v":11189782786942380395}')).toEqual({ v: '11189782786942380395' });
+  });
+
+  it('keeps safe integers as numbers', () => {
+    expect(parseJsonResponseLossless('{"v":123}')).toEqual({ v: 123 });
+    // MAX_SAFE_INTEGER is 16 digits but still safe
+    expect(parseJsonResponseLossless('{"v":9007199254740991}')).toEqual({ v: 9007199254740991 });
+  });
+
+  it('preserves a 16-digit integer just above the safe range as a string', () => {
+    expect(parseJsonResponseLossless('{"v":9007199254740993}')).toEqual({ v: '9007199254740993' });
+  });
+
+  it('preserves unsafe negative Int64 values as strings', () => {
+    expect(parseJsonResponseLossless('{"v":-9223372036854775808}')).toEqual({ v: '-9223372036854775808' });
+  });
+
+  it('keeps safe negative integers as numbers', () => {
+    expect(parseJsonResponseLossless('{"v":-42}')).toEqual({ v: -42 });
+  });
+
+  it('parses floats as numbers, including long mantissas and exponents', () => {
+    expect(parseJsonResponseLossless('{"a":1.5,"b":1.2345678901234567e20,"c":1e5,"d":-0.003147184}')).toEqual({
+      a: 1.5,
+      b: 1.2345678901234567e20,
+      c: 1e5,
+      d: -0.003147184,
+    });
+  });
+
+  it('does not touch digit runs inside string values', () => {
+    expect(parseJsonResponseLossless('{"msg":"id: 12345678901234567890 ok"}')).toEqual({
+      msg: 'id: 12345678901234567890 ok',
+    });
+  });
+
+  it('handles escaped quotes inside strings next to unsafe integers', () => {
+    expect(
+      parseJsonResponseLossless('{"msg":"he said \\" 99999999999999999999 \\" done","v":11189782786942380395}')
+    ).toEqual({ msg: 'he said " 99999999999999999999 " done', v: '11189782786942380395' });
+  });
+
+  it('handles an escaped backslash right before a closing quote', () => {
+    expect(parseJsonResponseLossless('{"path":"C:\\\\","v":11189782786942380395}')).toEqual({
+      path: 'C:\\',
+      v: '11189782786942380395',
+    });
+  });
+
+  it('preserves unsafe integers inside arrays', () => {
+    expect(parseJsonResponseLossless('[11189782786942380395,1,2]')).toEqual(['11189782786942380395', 1, 2]);
+  });
+
+  it('handles pretty-printed JSON with whitespace and newlines', () => {
+    expect(parseJsonResponseLossless('{\n\t"v": 11189782786942380395\n}')).toEqual({ v: '11189782786942380395' });
+  });
+
+  it('passes through already-quoted 64-bit values (output_format_json_quote_64bit_integers=1)', () => {
+    expect(parseJsonResponseLossless('{"v":"11189782786942380395"}')).toEqual({ v: '11189782786942380395' });
+  });
+
+  it('parses a full ClickHouse FORMAT JSON response shape', () => {
+    const text = `{
+      "meta": [{"name": "v", "type": "UInt64"}],
+      "data": [{"v": 11189782786942380395}],
+      "rows": 1,
+      "statistics": {"elapsed": 0.003147184, "rows_read": 1, "bytes_read": 1}
+    }`;
+    expect(parseJsonResponseLossless(text)).toEqual({
+      meta: [{ name: 'v', type: 'UInt64' }],
+      data: [{ v: '11189782786942380395' }],
+      rows: 1,
+      statistics: { elapsed: 0.003147184, rows_read: 1, bytes_read: 1 },
+    });
+  });
+
+  it('takes the native JSON.parse fast path for responses without long digit runs', () => {
+    const parseSpy = jest.spyOn(JSON, 'parse');
+    parseJsonResponseLossless('{"v":123}');
+    expect(parseSpy).toHaveBeenCalledWith('{"v":123}');
+    parseSpy.mockRestore();
+  });
+
+  it('returns non-string input unchanged (defensive passthrough)', () => {
+    const alreadyParsed = { data: [{ v: 1 }] };
+    expect(parseJsonResponseLossless(alreadyParsed)).toBe(alreadyParsed);
+    expect(parseJsonResponseLossless(null)).toBeNull();
+  });
+});
+
+describe('tryParseJson', () => {
+  it('restores a JSON error body to an object so isPermissionError can classify it', () => {
+    const body = '{"meta":[],"data":[],"exception":"Code: 497. DB::Exception: Not enough privileges."}';
+    expect(tryParseJson(body)).toEqual({
+      meta: [],
+      data: [],
+      exception: 'Code: 497. DB::Exception: Not enough privileges.',
+    });
+  });
+
+  it('returns a non-JSON (text/plain) error body unchanged', () => {
+    const body = 'Code: 497. DB::Exception: Not enough privileges.';
+    expect(tryParseJson(body)).toBe(body);
+  });
+
+  it('returns non-string input unchanged', () => {
+    const alreadyParsed = { exception: 'x' };
+    expect(tryParseJson(alreadyParsed)).toBe(alreadyParsed);
+    expect(tryParseJson(undefined)).toBeUndefined();
+  });
+
+  it("unwraps Grafana's processRequestError wrapper around a JSON error body", () => {
+    // backend_srv wraps string error bodies as {message, error, response}
+    // before the plugin's error handler runs
+    const body = '{"meta":[],"data":[],"exception":"Code: 497. DB::Exception: Not enough privileges."}';
+    const wrapped = { message: body, error: 'Internal Server Error', response: body };
+    expect(tryParseJson(wrapped)).toEqual({
+      meta: [],
+      data: [],
+      exception: 'Code: 497. DB::Exception: Not enough privileges.',
+    });
+  });
+
+  it("keeps Grafana's wrapper when the wrapped body is not JSON", () => {
+    const wrapped = {
+      message: 'Code: 497. DB::Exception: Not enough privileges.',
+      error: 'Internal Server Error',
+      response: 'Code: 497. DB::Exception: Not enough privileges.',
+    };
+    expect(tryParseJson(wrapped)).toBe(wrapped);
+  });
+});
+
+describe('end-to-end: raw ClickHouse text to table frame (issue #832)', () => {
+  it('delivers an unsafe UInt64 to the table untouched', () => {
+    const text =
+      '{"meta":[{"name":"v","type":"UInt64"}],"data":[{"v":11189782786942380395}],"rows":1,' +
+      '"statistics":{"elapsed":0.003,"rows_read":1,"bytes_read":1}}';
+    const response = parseJsonResponseLossless(text);
+    const sqlSeries = new SqlSeries({ refId: 'A', series: response.data, meta: response.meta, keys: [] });
+    const [table] = sqlSeries.toTable();
+    expect(table.columns).toEqual([{ text: 'v', type: 'string' }]);
+    expect(table.rows).toEqual([['11189782786942380395']]);
+  });
+});

--- a/src/datasource/losslessJson.ts
+++ b/src/datasource/losslessJson.ts
@@ -1,0 +1,73 @@
+import { parse as parseLossless, isInteger } from 'lossless-json';
+import { isSafeInteger } from './sql-series/bigIntUtils';
+
+/**
+ * Lossless parsing of ClickHouse FORMAT JSON responses.
+ *
+ * Native JSON.parse converts 64-bit integers to IEEE-754 doubles, silently
+ * rounding values above 2^53-1 (e.g. 11189782786942380395 becomes
+ * 11189782786942380000). ClickHouse >= 25.8 emits UInt64/Int64 as bare JSON
+ * numbers by default (output_format_json_quote_64bit_integers changed to 0,
+ * see ClickHouse/ClickHouse#86553), so the response is fetched as text and
+ * parsed with lossless-json: integers outside the safe range stay strings,
+ * everything else parses to the same values native JSON.parse would produce.
+ * The resulting strings are the same shape the sql-series transforms already
+ * handle for quoted 64-bit output.
+ *
+ * @see https://github.com/Altinity/clickhouse-grafana/issues/832
+ */
+
+const DIGIT_RUN_16 = /\d{16,}/;
+
+// Integers that cannot be represented exactly in a JS number stay strings;
+// safe integers and floats become regular numbers
+const parseNumber = (value: string): number | string =>
+  isInteger(value) && !isSafeInteger(value) ? value : Number(value);
+
+/**
+ * Parse a raw ClickHouse HTTP response body without losing 64-bit precision.
+ * Responses without 16+ digit runs (the vast majority) take the native
+ * JSON.parse fast path. Non-string input is returned unchanged so call sites
+ * stay safe if a response arrives already parsed.
+ */
+export const parseJsonResponseLossless = (data: any): any => {
+  if (typeof data !== 'string') {
+    return data;
+  }
+  if (!DIGIT_RUN_16.test(data)) {
+    return JSON.parse(data);
+  }
+  return parseLossless(data, undefined, parseNumber);
+};
+
+/**
+ * Best-effort variant for error bodies: with responseType 'text' an HTTP
+ * error arrives as a raw string, but downstream classification (e.g.
+ * isPermissionError reading error.data.exception) expects the parsed object
+ * Grafana used to provide. Restores the object when the body is JSON and
+ * returns the input unchanged otherwise (e.g. text/plain ClickHouse errors).
+ *
+ * Grafana's backend_srv processRequestError runs before the plugin's error
+ * handlers and wraps string bodies as {message, error, response} — unwrap
+ * that shape too, using the untouched body kept in `response`.
+ */
+export const tryParseJson = (data: any): any => {
+  if (typeof data === 'string') {
+    try {
+      return parseJsonResponseLossless(data);
+    } catch (e) {
+      return data;
+    }
+  }
+  if (data && typeof data.response === 'string') {
+    try {
+      const parsed = parseJsonResponseLossless(data.response);
+      if (parsed && typeof parsed === 'object') {
+        return parsed;
+      }
+    } catch (e) {
+      // fall through: keep the wrapper for non-JSON bodies
+    }
+  }
+  return data;
+};

--- a/src/views/ConfigEditor/FormParts/DefaultValues/DefaultValues.api.test.ts
+++ b/src/views/ConfigEditor/FormParts/DefaultValues/DefaultValues.api.test.ts
@@ -1,0 +1,47 @@
+import { of } from 'rxjs';
+
+const fetchMock = jest.fn();
+jest.mock('@grafana/runtime', () => ({
+  getBackendSrv: () => ({ fetch: fetchMock }),
+  getTemplateSrv: jest.fn(),
+  getGrafanaLiveSrv: jest.fn(),
+  config: { bootData: { user: { login: '' } } },
+  DataSourceWithBackend: class {},
+}));
+jest.mock('../../../QueryEditor/QueryEditor', () => ({
+  QueryEditor: () => null,
+}));
+
+import { getOptions } from './DefaultValues.api';
+
+describe('DefaultValues.api getOptions', () => {
+  const datasourceOptions = {
+    access: 'proxy',
+    uid: 'abc',
+    jsonData: { usePOST: true },
+  };
+
+  it('parses the raw text response into an object (responseType is text since issue #832)', async () => {
+    fetchMock.mockReturnValue(
+      of({ data: '{"meta":[{"name":"d","type":"DateTime"}],"data":[{"d":"2024-01-01"}],"rows":1}' })
+    );
+
+    const result = await getOptions('SELECT 1 FORMAT JSON', 'http://x', datasourceOptions);
+
+    expect(result).toEqual({
+      meta: [{ name: 'd', type: 'DateTime' }],
+      data: [{ d: '2024-01-01' }],
+      rows: 1,
+    });
+  });
+
+  it('preserves unsafe UInt64 values from the raw text response', async () => {
+    fetchMock.mockReturnValue(
+      of({ data: '{"meta":[{"name":"v","type":"UInt64"}],"data":[{"v":11189782786942380395}],"rows":1}' })
+    );
+
+    const result = await getOptions('SELECT 1 FORMAT JSON', 'http://x', datasourceOptions);
+
+    expect(result.data).toEqual([{ v: '11189782786942380395' }]);
+  });
+});

--- a/src/views/ConfigEditor/FormParts/DefaultValues/DefaultValues.api.ts
+++ b/src/views/ConfigEditor/FormParts/DefaultValues/DefaultValues.api.ts
@@ -1,5 +1,6 @@
 import { getBackendSrv } from '@grafana/runtime';
 import { CHDataSource } from '../../../../datasource/datasource';
+import { parseJsonResponseLossless, tryParseJson } from '../../../../datasource/losslessJson';
 
 export const getOptions = async (query: string, url: string, datasourceOptions: any): Promise<any> => {
   const backendSrv = getBackendSrv();
@@ -16,10 +17,14 @@ export const getOptions = async (query: string, url: string, datasourceOptions: 
   return new Promise((resolve, reject) => {
     backendSrv.fetch(queryParams).subscribe(
       (response) => {
-        resolve(response.data);
+        try {
+          resolve(parseJsonResponseLossless(response.data));
+        } catch (parseError) {
+          reject(parseError);
+        }
       },
       (e) => {
-        reject(e);
+        reject({ ...e, data: tryParseJson(e?.data) });
       }
     );
   });


### PR DESCRIPTION
fix #832 