### PR TITLE
fix CI code coverage collection

### DIFF
--- a/.github/actions/testflows-suite/action.yml
+++ b/.github/actions/testflows-suite/action.yml
@@ -64,6 +64,15 @@ runs:
           --suite ${{ inputs.suite-name }} "${SCENARIO_ARG[@]}" \
           --log raw.log -o short
 
+    - name: Stop cluster to flush Go coverage counters
+      if: always()
+      shell: bash
+      # The -cover instrumented plugin writes GOCOVERDIR counter files only on
+      # graceful exit. Normally regression.py brings the cluster down itself;
+      # this is the safety net for failed/aborted runs so partial coverage
+      # still reaches the artifact.
+      run: docker compose --profile test stop -t 60 || true
+
     - name: Create reports
       if: always()
       shell: bash
@@ -77,7 +86,7 @@ runs:
         path: |
           go_coverage/raw/
           tests/testflows/coverage/raw/
-        if-no-files-found: ignore
+        if-no-files-found: warn
 
     - name: Upload testflows logs
       if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,40 +52,19 @@ jobs:
       - name: Test frontend
         run: npm run test:ci
 
-      - name: Report frontend coverage
-        uses: coverallsapp/github-action@v2
-        with:
-          fail-on-error: false
-          file: ./coverage/lcov.info
-          format: lcov
-          flag-name: frontend
-          parallel: true
-
       - name: Build frontend
         run: npm run build
 
+      # Coverage is reported to Coveralls only by the testflows workflow, which
+      # merges these same unit-test results with the e2e counters; a second
+      # upload from here would create a competing Coveralls build for the same
+      # commit and make the badge flip between the two numbers.
       - name: Test backend
         if: steps.check-for-backend.outputs.has-backend == 'true'
         uses: magefile/mage-action@v3
         with:
           version: latest
           args: coverage
-
-      - name: Report golang coverage
-        if: steps.check-for-backend.outputs.has-backend == 'true'
-        uses: coverallsapp/github-action@v2
-        with:
-          fail-on-error: false
-          file: ./coverage/backend.out
-          format: golang
-          flag-name: backend
-          parallel: true
-
-      - name: Finish coveralls (aggregate frontend + backend)
-        uses: coverallsapp/github-action@v2
-        with:
-          fail-on-error: false
-          parallel-finished: true
 
       - name: Build backend
         if: steps.check-for-backend.outputs.has-backend == 'true'

--- a/.github/workflows/testflows.yml
+++ b/.github/workflows/testflows.yml
@@ -43,6 +43,15 @@ jobs:
           name: build-frontend
           path: dist/
 
+      # frontend_coverage_builder also runs `npm run test:coverage`; keep the
+      # jest unit-test coverage so the coverage job can merge it with e2e data
+      - name: Upload frontend unit-test coverage
+        uses: actions/upload-artifact@v7
+        with:
+          name: frontend-unit-coverage
+          path: coverage/coverage-final.json
+          if-no-files-found: error
+
   prepare-backend-build:
     runs-on: ubuntu-latest
     permissions:
@@ -208,22 +217,38 @@ jobs:
           pattern: raw-coverage-*-fixed
           path: raw-coverage
 
+      # unit/integration `go test -test.gocoverdir` pods live at go_coverage/
+      # root inside this artifact; they never pass through the tests jobs
+      - name: Download backend build (unit-test coverage pods)
+        uses: actions/download-artifact@v7
+        with:
+          name: build-backend
+          path: build-backend
+
+      - name: Download frontend unit-test coverage
+        uses: actions/download-artifact@v7
+        with:
+          name: frontend-unit-coverage
+          path: frontend-unit-coverage
+
       - name: Merge and generate backend coverage
         run: |
+          if ! ls raw-coverage/*/go_coverage/raw/covcounters.* 1>/dev/null 2>&1; then
+            echo "::error::No e2e Go coverage counters in any suite artifact — the instrumented plugin did not flush GOCOVERDIR data"
+            exit 1
+          fi
           mkdir -p go_coverage/raw
           for dir in raw-coverage/*/go_coverage/raw/; do
             cp -r "$dir"* go_coverage/raw/ 2>/dev/null || true
           done
-          if ls go_coverage/raw/cov* 1>/dev/null 2>&1; then
-            go tool covdata textfmt -i=go_coverage/raw -o=go_coverage/coverage.txt
-            go tool cover -html=go_coverage/coverage.txt -o=go_coverage/coverage.html
-          else
-            echo "No backend coverage data found"
-          fi
+          cp build-backend/go_coverage/covmeta.* build-backend/go_coverage/covcounters.* go_coverage/raw/ 2>/dev/null || true
+          go tool covdata percent -i=go_coverage/raw
+          go tool covdata textfmt -i=go_coverage/raw -o=go_coverage/coverage.txt
+          go tool cover -html=go_coverage/coverage.txt -o=go_coverage/coverage.html
 
       - name: Normalize frontend coverage paths
         run: |
-          for f in raw-coverage/*/tests/testflows/coverage/raw/*.json; do
+          for f in raw-coverage/*/tests/testflows/coverage/raw/*.json frontend-unit-coverage/coverage-final.json; do
             [ -f "$f" ] || continue
             jq '
               with_entries(
@@ -239,14 +264,8 @@ jobs:
           for dir in raw-coverage/*/tests/testflows/coverage/raw/; do
             cp -r "$dir"* .nyc_output/ 2>/dev/null || true
           done
-          if ls .nyc_output/* 1>/dev/null 2>&1; then
-            if [ -f coverage/coverage-final.json ]; then
-              cp coverage/coverage-final.json .nyc_output/
-            fi
-            npx nyc report --temp-dir .nyc_output --reporter html --reporter=lcov --report-dir=./tests/testflows/coverage
-          else
-            echo "No frontend coverage data found"
-          fi
+          cp frontend-unit-coverage/coverage-final.json .nyc_output/unit-coverage-final.json
+          npx nyc report --temp-dir .nyc_output --reporter html --reporter=lcov --report-dir=./tests/testflows/coverage
 
       - name: Verify frontend coverage
         run: |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -74,6 +74,9 @@ services:
       GF_UNIFIED_ALERTING_ENABLED: ${GF_UNIFIED_ALERTING_ENABLED:-true}
       GF_ALERTING_ENABLED: ${GF_ALERTING_ENABLED:-false}
       GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: vertamedia-clickhouse-datasource
+      # Grafana >= 12.4 no longer forwards host env vars to plugin processes,
+      # without this the plugin never sees GOCOVERDIR and writes no coverage counters
+      GF_PLUGINS_FORWARD_HOST_ENV_VARS: vertamedia-clickhouse-datasource
     depends_on:
       - clickhouse
 
@@ -104,6 +107,8 @@ services:
       GF_UNIFIED_ALERTING_ENABLED: ${GF_UNIFIED_ALERTING_ENABLED:-false}
       GF_ALERTING_ENABLED: ${GF_ALERTING_ENABLED:-true}
       GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: vertamedia-clickhouse-datasource
+      # no-op on 10.4.3 (forwards everything anyway), needed once the legacy pin moves past 12.4
+      GF_PLUGINS_FORWARD_HOST_ENV_VARS: vertamedia-clickhouse-datasource
     depends_on:
       - clickhouse
 
@@ -237,7 +242,7 @@ services:
         (command -v mage || go install -v github.com/magefile/mage@latest) &&
         mkdir -p /go/src/grafana-clickhouse/go_coverage/raw &&
         go env &&
-        go test -timeout 1m -cover -failfast -tags=integration -run "${RUN_TESTS:-.+}" -v ./pkg/... -test.gocoverdir="/go/src/grafana-clickhouse/go_coverage" &&
+        go test -timeout 1m -cover -coverpkg=./... -failfast -tags=integration -run "${RUN_TESTS:-.+}" -v ./pkg/... -test.gocoverdir="/go/src/grafana-clickhouse/go_coverage" &&
         GOOS=linux GOARCH=amd64 go build -cover -buildvcs=false -o ./dist/altinity-clickhouse-plugin_linux_amd64 ./pkg/ &&
         chmod +x dist/altinity-clickhouse-plugin*
       "


### PR DESCRIPTION
Grafana >= 12.4 stopped forwarding host env vars to plugins, so the instrumented plugin never saw GOCOVERDIR and wrote no e2e counters.