### PR TITLE
slide the streaming window instead of pinning its start

### DIFF
--- a/pkg/streaming.go
+++ b/pkg/streaming.go
@@ -108,6 +108,27 @@ func roundDownTo(t time.Time, intervalSec int64) time.Time {
 	return time.Unix(rounded, 0)
 }
 
+// resolveWindowSpan returns how wide the streamed window should be. Streaming always polls
+// up to now(), so only the width of the dashboard range matters, not its absolute position.
+func resolveWindowSpan(sq *streamQuery, from, now time.Time) time.Duration {
+	if sq.TimeRange.To != "" {
+		if to, err := time.Parse(time.RFC3339, sq.TimeRange.To); err == nil && to.After(from) {
+			return to.Sub(from)
+		}
+	}
+	if span := now.Sub(from); span > 0 {
+		return span
+	}
+	return time.Hour
+}
+
+// windowStart returns the lower edge of the sliding window ending at end.
+// end must already be bucket-aligned, which keeps the window a constant number of
+// buckets wide so identical ticks still dedup by fingerprint.
+func windowStart(end time.Time, span time.Duration, intervalSec int64) time.Time {
+	return roundDownTo(end.Add(-span), intervalSec)
+}
+
 // SubscribeStream validates a subscription request and allows the client to subscribe.
 func (ds *ClickHouseDatasource) SubscribeStream(_ context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
 	backend.Logger.Debug(fmt.Sprintf("SubscribeStream called for path: %s", req.Path))
@@ -180,18 +201,22 @@ func (ds *ClickHouseDatasource) RunStream(ctx context.Context, req *backend.RunS
 	// Parse query $interval to round timestamps to complete buckets.
 	// This prevents the last partial bucket from causing visual jumps.
 	queryIntervalSec := parseIntervalSeconds(sq.Interval)
-	backend.Logger.Debug(fmt.Sprintf("[streaming] dashboardFrom=%s | queryInterval=%ds",
-		dashboardFrom.Format(time.RFC3339), queryIntervalSec))
+
+	windowSpan := resolveWindowSpan(&sq, dashboardFrom, time.Now())
+
+	backend.Logger.Debug(fmt.Sprintf("[streaming] dashboardFrom=%s | queryInterval=%ds | windowSpan=%s",
+		dashboardFrom.Format(time.RFC3339), queryIntervalSec, windowSpan))
 
 	if mode == "full" {
-		return ds.runFullRefreshLoop(ctx, req, sender, &sq, dashboardFrom, intervalMs, ticker, queryIntervalSec)
+		return ds.runFullRefreshLoop(ctx, req, sender, &sq, windowSpan, intervalMs, ticker, queryIntervalSec)
 	}
-	return ds.runDeltaLoop(ctx, req, sender, &sq, dashboardFrom, ticker, queryIntervalSec)
+	return ds.runDeltaLoop(ctx, req, sender, &sq, windowSpan, ticker, queryIntervalSec)
 }
 
 // runDeltaLoop implements delta streaming with server-side accumulation:
-//   - Tick 1: queries the full time range [dashboardFrom, now] and stores frames in memory
+//   - Tick 1: queries the sliding window [now-windowSpan, now] and stores frames in memory
 //   - Tick 2+: queries only the narrow window [lastTo, now], merges new rows into stored frames
+//     and trims rows that slid out of the window
 //
 // The frontend always receives the complete accumulated dataset via Replace mode.
 // This avoids Grafana's Append buffer issues with multi-frame responses (e.g. GROUP BY host)
@@ -204,7 +229,7 @@ func (ds *ClickHouseDatasource) runDeltaLoop(
 	req *backend.RunStreamRequest,
 	sender *backend.StreamSender,
 	sq *streamQuery,
-	dashboardFrom time.Time,
+	windowSpan time.Duration,
 	ticker *time.Ticker,
 	queryIntervalSec int64,
 ) error {
@@ -224,13 +249,14 @@ func (ds *ClickHouseDatasource) runDeltaLoop(
 	// Server-side accumulated frames, keyed by frame name
 	accumulated := map[string]*data.Frame{}
 
-	// Tick 1: full range [dashboardFrom, now] — initial data load
+	// Tick 1: whole window [now-windowSpan, now] — initial data load
 	tickCount++
 	now := roundDownTo(time.Now(), queryIntervalSec)
+	cutoff := windowStart(now, windowSpan, queryIntervalSec)
 	backend.Logger.Debug(fmt.Sprintf("[streaming] tick #%d | DELTA/INITIAL | from=%s | to=%s",
-		tickCount, dashboardFrom.Format("15:04:05"), now.Format("15:04:05")))
+		tickCount, cutoff.Format("15:04:05"), now.Format("15:04:05")))
 
-	response := ds.executeStreamEvalQuery(req.PluginContext, ctx, sq, dashboardFrom, now)
+	response := ds.executeStreamEvalQuery(req.PluginContext, ctx, sq, cutoff, now)
 	if response.Error != nil {
 		backend.Logger.Error(fmt.Sprintf("[streaming] tick #%d | QUERY ERROR: %s", tickCount, response.Error))
 		ds.sendErrorFrame(sender, sq.RefId, response.Error.Error())
@@ -269,14 +295,16 @@ func (ds *ClickHouseDatasource) runDeltaLoop(
 				backend.Logger.Debug(fmt.Sprintf("[streaming] tick #%d | DELTA: skipped (now <= lastTo)", tickCount))
 				continue
 			}
+			cutoff = windowStart(now, windowSpan, queryIntervalSec)
 
 			// Shift from back by lookback to re-query recent incomplete buckets
 			deltaFrom := lastTo
 			if lookbackPoints > 0 && queryIntervalSec > 0 {
 				lookbackDuration := time.Duration(int64(lookbackPoints)*queryIntervalSec) * time.Second
 				deltaFrom = lastTo.Add(-lookbackDuration)
-				if deltaFrom.Before(dashboardFrom) {
-					deltaFrom = dashboardFrom
+				// Rows below the cutoff are trimmed by this tick, so re-querying them is waste.
+				if deltaFrom.Before(cutoff) {
+					deltaFrom = cutoff
 				}
 			}
 
@@ -306,8 +334,8 @@ func (ds *ClickHouseDatasource) runDeltaLoop(
 			}
 
 			if hasNewData {
-				// Trim data older than dashboardFrom to prevent unbounded memory growth
-				trimAccumulatedFrames(accumulated, dashboardFrom)
+				// Drop rows that slid out of the window, else the accumulator grows forever.
+				trimAccumulatedFrames(accumulated, cutoff)
 				ds.sendAccumulatedFrames(sender, accumulated, sq, tickCount)
 			} else {
 				backend.Logger.Debug(fmt.Sprintf("[streaming] tick #%d | DELTA: no new rows", tickCount))
@@ -389,19 +417,24 @@ func trimAccumulatedFrames(accumulated map[string]*data.Frame, cutoff time.Time)
 	cutoffMs := cutoff.UnixMilli()
 	for name, frame := range accumulated {
 		if len(frame.Fields) == 0 || frame.Rows() == 0 {
+			delete(accumulated, name)
 			continue
 		}
 		timeField := frame.Fields[0]
-		// Find the first row >= cutoff
-		firstValid := -1
+		// Collect rows to keep. A predicate, not a prefix cut: upsertFrameRows appends
+		// backfilled rows at the end, so the frame is not always time-ordered.
+		keep := make([]int, 0, frame.Rows())
 		for r := 0; r < frame.Rows(); r++ {
 			if t, ok := timeField.At(r).(time.Time); ok && t.UnixMilli() >= cutoffMs {
-				firstValid = r
-				break
+				keep = append(keep, r)
 			}
 		}
-		if firstValid <= 0 {
-			continue // nothing to trim (or all rows are valid)
+		if len(keep) == frame.Rows() {
+			continue // nothing stale
+		}
+		if len(keep) == 0 {
+			delete(accumulated, name) // series slid out of the window entirely
+			continue
 		}
 		// Rebuild fields with only valid rows
 		trimmed := data.NewFrame(frame.Name)
@@ -411,7 +444,7 @@ func trimAccumulatedFrames(accumulated map[string]*data.Frame, cutoff time.Time)
 			newField := data.NewFieldFromFieldType(field.Type(), 0)
 			newField.Name = field.Name
 			newField.Labels = field.Labels
-			for r := firstValid; r < field.Len(); r++ {
+			for _, r := range keep {
 				newField.Append(field.At(r))
 			}
 			trimmed.Fields = append(trimmed.Fields, newField)
@@ -578,7 +611,7 @@ func toFloat64(v interface{}) float64 {
 	}
 }
 
-// runFullRefreshLoop: every tick re-queries [dashboardFrom, now()].
+// runFullRefreshLoop: every tick re-queries the sliding window [now()-windowSpan, now()].
 // Only sends data when the result actually changes (fingerprint comparison).
 // Frontend uses Replace mode.
 func (ds *ClickHouseDatasource) runFullRefreshLoop(
@@ -586,7 +619,7 @@ func (ds *ClickHouseDatasource) runFullRefreshLoop(
 	req *backend.RunStreamRequest,
 	sender *backend.StreamSender,
 	sq *streamQuery,
-	dashboardFrom time.Time,
+	windowSpan time.Duration,
 	intervalMs int,
 	ticker *time.Ticker,
 	queryIntervalSec int64,
@@ -597,9 +630,10 @@ func (ds *ClickHouseDatasource) runFullRefreshLoop(
 	// First tick immediately
 	tickCount++
 	now := roundDownTo(time.Now(), queryIntervalSec)
+	from := windowStart(now, windowSpan, queryIntervalSec)
 	backend.Logger.Debug(fmt.Sprintf("[streaming] tick #%d | FULL_REFRESH | from=%s | to=%s",
-		tickCount, dashboardFrom.Format("15:04:05"), now.Format("15:04:05")))
-	ds.sendFramesWithDedup(ctx, req.PluginContext, sender, sq, dashboardFrom, now, &lastFingerprint, tickCount)
+		tickCount, from.Format("15:04:05"), now.Format("15:04:05")))
+	ds.sendFramesWithDedup(ctx, req.PluginContext, sender, sq, from, now, &lastFingerprint, tickCount)
 
 	for {
 		select {
@@ -609,9 +643,10 @@ func (ds *ClickHouseDatasource) runFullRefreshLoop(
 		case <-ticker.C:
 			tickCount++
 			now = roundDownTo(time.Now(), queryIntervalSec)
+			from = windowStart(now, windowSpan, queryIntervalSec)
 			backend.Logger.Debug(fmt.Sprintf("[streaming] tick #%d | FULL_REFRESH | from=%s | to=%s",
-				tickCount, dashboardFrom.Format("15:04:05"), now.Format("15:04:05")))
-			ds.sendFramesWithDedup(ctx, req.PluginContext, sender, sq, dashboardFrom, now, &lastFingerprint, tickCount)
+				tickCount, from.Format("15:04:05"), now.Format("15:04:05")))
+			ds.sendFramesWithDedup(ctx, req.PluginContext, sender, sq, from, now, &lastFingerprint, tickCount)
 		}
 	}
 }

--- a/pkg/streaming.go
+++ b/pkg/streaming.go
@@ -256,6 +256,10 @@ func (ds *ClickHouseDatasource) runDeltaLoop(
 	backend.Logger.Debug(fmt.Sprintf("[streaming] tick #%d | DELTA/INITIAL | from=%s | to=%s",
 		tickCount, cutoff.Format("15:04:05"), now.Format("15:04:05")))
 
+	// Last frame published to the client; kept as the schema for the zero-row frame that
+	// clears the panel once every series has left the window.
+	var lastSent *data.Frame
+
 	response := ds.executeStreamEvalQuery(req.PluginContext, ctx, sq, cutoff, now)
 	if response.Error != nil {
 		backend.Logger.Error(fmt.Sprintf("[streaming] tick #%d | QUERY ERROR: %s", tickCount, response.Error))
@@ -267,7 +271,7 @@ func (ds *ClickHouseDatasource) runDeltaLoop(
 				accumulated[name] = frame
 			}
 		}
-		ds.sendAccumulatedFrames(sender, accumulated, sq, tickCount)
+		lastSent = ds.sendAccumulatedFrames(sender, accumulated, sq, tickCount, nil)
 	}
 	lastTo := now
 
@@ -333,10 +337,12 @@ func (ds *ClickHouseDatasource) runDeltaLoop(
 				}
 			}
 
-			if hasNewData {
-				// Drop rows that slid out of the window, else the accumulator grows forever.
-				trimAccumulatedFrames(accumulated, cutoff)
-				ds.sendAccumulatedFrames(sender, accumulated, sq, tickCount)
+			// Trim on every successful tick, not just when rows arrived: the window keeps
+			// sliding while a source is silent, and those points must still leave the panel.
+			trimmed := trimAccumulatedFrames(accumulated, cutoff)
+
+			if hasNewData || trimmed {
+				lastSent = ds.sendAccumulatedFrames(sender, accumulated, sq, tickCount, lastSent)
 			} else {
 				backend.Logger.Debug(fmt.Sprintf("[streaming] tick #%d | DELTA: no new rows", tickCount))
 			}
@@ -413,11 +419,15 @@ func upsertFrameRows(dst, src *data.Frame) {
 
 // trimAccumulatedFrames removes rows older than cutoff from all accumulated frames.
 // This prevents unbounded memory growth for long-running streams.
-func trimAccumulatedFrames(accumulated map[string]*data.Frame, cutoff time.Time) {
+// It reports whether any row or series was removed, so the caller knows the client needs
+// a refreshed frame even when the query itself returned nothing new.
+func trimAccumulatedFrames(accumulated map[string]*data.Frame, cutoff time.Time) bool {
 	cutoffMs := cutoff.UnixMilli()
+	changed := false
 	for name, frame := range accumulated {
 		if len(frame.Fields) == 0 || frame.Rows() == 0 {
 			delete(accumulated, name)
+			changed = true
 			continue
 		}
 		timeField := frame.Fields[0]
@@ -434,8 +444,10 @@ func trimAccumulatedFrames(accumulated map[string]*data.Frame, cutoff time.Time)
 		}
 		if len(keep) == 0 {
 			delete(accumulated, name) // series slid out of the window entirely
+			changed = true
 			continue
 		}
+		changed = true
 		// Rebuild fields with only valid rows
 		trimmed := data.NewFrame(frame.Name)
 		trimmed.RefID = frame.RefID
@@ -451,30 +463,52 @@ func trimAccumulatedFrames(accumulated map[string]*data.Frame, cutoff time.Time)
 		}
 		accumulated[name] = trimmed
 	}
+	return changed
 }
 
 // sendAccumulatedFrames merges accumulated frames into a single wide-format frame
 // and sends it via Replace. Grafana's streaming Replace mode only keeps the last
 // frame sent per channel, so we must combine all series into one frame.
+// It returns the frame that was sent, which the caller keeps as the schema to fall back on
+// once every series has left the window: Replace keeps the previous frame on the client, so
+// an emptied accumulator has to be published as a zero-row frame rather than silence.
 func (ds *ClickHouseDatasource) sendAccumulatedFrames(
 	sender *backend.StreamSender,
 	accumulated map[string]*data.Frame,
 	sq *streamQuery,
 	tickCount int,
-) {
+	lastSent *data.Frame,
+) *data.Frame {
 	wide := mergeFramesToWide(accumulated)
 	if wide == nil {
-		backend.Logger.Debug(fmt.Sprintf("[streaming] tick #%d | DELTA: nothing to send", tickCount))
-		return
+		if lastSent == nil {
+			backend.Logger.Debug(fmt.Sprintf("[streaming] tick #%d | DELTA: nothing to send", tickCount))
+			return nil
+		}
+		wide = emptyLike(lastSent)
 	}
 	wide.RefID = sq.RefId
 	addStreamingNotice(wide, "delta", tickCount, wide.Rows())
 	if err := sender.SendFrame(wide, data.IncludeAll); err != nil {
 		backend.Logger.Error(fmt.Sprintf("[streaming] tick #%d | SendFrame ERROR: %s", tickCount, err))
-		return
+		return lastSent
 	}
 	backend.Logger.Debug(fmt.Sprintf("[streaming] tick #%d | refId=%s | series=%d | rows=%d",
 		tickCount, sq.RefId, len(accumulated), wide.Rows()))
+	return wide
+}
+
+// emptyLike returns a zero-row frame with the same schema, used to clear the panel.
+func emptyLike(frame *data.Frame) *data.Frame {
+	empty := data.NewFrame(frame.Name)
+	empty.RefID = frame.RefID
+	for _, field := range frame.Fields {
+		f := data.NewFieldFromFieldType(field.Type(), 0)
+		f.Name = field.Name
+		f.Labels = field.Labels
+		empty.Fields = append(empty.Fields, f)
+	}
+	return empty
 }
 
 // mergeFramesToWide combines multiple frames that share a common time field

--- a/pkg/streaming_test.go
+++ b/pkg/streaming_test.go
@@ -1,8 +1,16 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+
 	"context"
 	"encoding/json"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"math"
 	"testing"
 	"time"
@@ -142,4 +150,239 @@ func TestUpsertFrameRowsMergesMatchingTypes(t *testing.T) {
 	require.Equal(t, 2, dst.Rows())
 	require.Equal(t, 42.0, dst.Fields[1].At(0), "existing bucket must be updated in place")
 	require.Equal(t, 2.0, dst.Fields[1].At(1), "new bucket must be appended")
+}
+
+func TestResolveWindowSpan(t *testing.T) {
+	from := time.Date(2026, 8, 4, 10, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		to   string
+		now  time.Time
+		want time.Duration
+	}{
+		{"dashboard range", from.Add(time.Hour).Format(time.RFC3339), from.Add(time.Second), time.Hour},
+		{"millisecond ISO from the frontend", "2026-08-04T11:00:00.000Z", from.Add(time.Second), time.Hour},
+		{"absolute past range", from.Add(24 * time.Hour).Format(time.RFC3339), time.Now(), 24 * time.Hour},
+		{"missing to falls back to elapsed", "", from.Add(90 * time.Second), 90 * time.Second},
+		{"unparsable to falls back to elapsed", "1700000000", from.Add(90 * time.Second), 90 * time.Second},
+		{"to before from falls back to elapsed", from.Add(-time.Hour).Format(time.RFC3339), from.Add(90 * time.Second), 90 * time.Second},
+		{"from in the future falls back to default", "", from.Add(-time.Hour), time.Hour},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sq := &streamQuery{}
+			sq.TimeRange.To = tt.to
+
+			got := resolveWindowSpan(sq, from, tt.now)
+
+			require.Equal(t, tt.want, got)
+			require.Greater(t, got, time.Duration(0))
+		})
+	}
+}
+
+// The window must stay a constant number of buckets wide and advance one whole bucket at
+// a time, otherwise identical ticks would stop deduplicating by fingerprint.
+func TestWindowStartKeepsConstantWidth(t *testing.T) {
+	const intervalSec = 60
+	span := time.Hour
+	base := time.Unix(1785000000, 0)
+
+	var prevFrom, prevTo time.Time
+	for offset := 0; offset < 3600; offset++ {
+		to := roundDownTo(base.Add(time.Duration(offset)*time.Second), intervalSec)
+		from := windowStart(to, span, intervalSec)
+
+		require.Equal(t, span, to.Sub(from), "window width must not drift")
+		require.Zero(t, from.Unix()%intervalSec, "both edges must sit on bucket boundaries")
+		require.Zero(t, to.Unix()%intervalSec)
+
+		if !prevTo.IsZero() {
+			if to.Equal(prevTo) {
+				require.True(t, from.Equal(prevFrom), "from must not move within a bucket")
+			} else {
+				require.Equal(t, int64(intervalSec), to.Unix()-prevTo.Unix())
+				require.Equal(t, int64(intervalSec), from.Unix()-prevFrom.Unix())
+			}
+		}
+		prevFrom, prevTo = from, to
+	}
+}
+
+func TestWindowStartWithoutBucketAlignment(t *testing.T) {
+	// Sub-second $interval parses to 0, which disables rounding.
+	now := time.Unix(1785000000, 500)
+	require.Equal(t, 10*time.Minute, now.Sub(windowStart(now, 10*time.Minute, 0)))
+}
+
+func accumFrame(times []time.Time, values []float64) *data.Frame {
+	return data.NewFrame("",
+		data.NewField("t", nil, times),
+		data.NewField("v", nil, values),
+	)
+}
+
+func TestTrimAccumulatedFrames(t *testing.T) {
+	base := time.Unix(1785000000, 0)
+
+	t.Run("drops rows below the cutoff", func(t *testing.T) {
+		acc := map[string]*data.Frame{"s": accumFrame(
+			[]time.Time{base, base.Add(time.Minute), base.Add(2 * time.Minute)},
+			[]float64{1, 2, 3},
+		)}
+
+		trimAccumulatedFrames(acc, base.Add(time.Minute))
+
+		require.Equal(t, 2, acc["s"].Rows())
+		require.Equal(t, 2.0, acc["s"].Fields[1].At(0))
+	})
+
+	t.Run("removes a series that slid out of the window entirely", func(t *testing.T) {
+		acc := map[string]*data.Frame{"s": accumFrame([]time.Time{base}, []float64{1})}
+
+		trimAccumulatedFrames(acc, base.Add(time.Hour))
+
+		require.NotContains(t, acc, "s")
+	})
+
+	t.Run("leaves a fully valid frame untouched", func(t *testing.T) {
+		frame := accumFrame([]time.Time{base, base.Add(time.Minute)}, []float64{1, 2})
+		acc := map[string]*data.Frame{"s": frame}
+
+		trimAccumulatedFrames(acc, base)
+
+		require.Same(t, frame, acc["s"])
+	})
+
+	t.Run("trims out-of-order rows appended by backfill", func(t *testing.T) {
+		acc := map[string]*data.Frame{"s": accumFrame(
+			[]time.Time{base.Add(2 * time.Minute), base.Add(3 * time.Minute), base},
+			[]float64{3, 4, 1},
+		)}
+
+		trimAccumulatedFrames(acc, base.Add(time.Minute))
+
+		require.Equal(t, 2, acc["s"].Rows(), "the stale row at the end must go, not survive a prefix cut")
+		require.Equal(t, 3.0, acc["s"].Fields[1].At(0))
+		require.Equal(t, 4.0, acc["s"].Fields[1].At(1))
+	})
+}
+
+// The accumulator used to grow forever because the trim cutoff never advanced.
+func TestDeltaAccumulatorStopsGrowing(t *testing.T) {
+	const intervalSec = 60
+	span := 10 * time.Minute
+	base := time.Unix(1785000000, 0)
+
+	acc := map[string]*data.Frame{"s": accumFrame([]time.Time{base}, []float64{0})}
+
+	for tick := 1; tick <= 500; tick++ {
+		now := roundDownTo(base.Add(time.Duration(tick)*time.Minute), intervalSec)
+		upsertFrameRows(acc["s"], accumFrame([]time.Time{now}, []float64{float64(tick)}))
+		trimAccumulatedFrames(acc, windowStart(now, span, intervalSec))
+
+		require.LessOrEqual(t, acc["s"].Rows(), 11, "tick %d: window holds at most span/interval+1 rows", tick)
+	}
+	require.Equal(t, 11, acc["s"].Rows())
+}
+
+type fakeInstanceManager struct{ settings *DatasourceSettings }
+
+func (f *fakeInstanceManager) Get(context.Context, backend.PluginContext) (instancemgmt.Instance, error) {
+	return f.settings, nil
+}
+
+func (f *fakeInstanceManager) Do(context.Context, backend.PluginContext, instancemgmt.InstanceCallbackFunc) error {
+	return nil
+}
+
+// clickhouseStub records the SQL it is asked to run and answers with an empty result set.
+type clickhouseStub struct {
+	mu      sync.Mutex
+	queries []string
+}
+
+func (s *clickhouseStub) record(q string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.queries = append(s.queries, q)
+}
+
+func (s *clickhouseStub) recorded() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.queries...)
+}
+
+func newStubDatasource(t *testing.T) (*ClickHouseDatasource, *clickhouseStub) {
+	t.Helper()
+	stub := &clickhouseStub{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query().Get("query")
+		if strings.Contains(query, "timezone()") {
+			_, _ = w.Write([]byte(`{"meta":[{"name":"timezone()","type":"String"}],"data":[{"timezone()":"UTC"}]}`))
+			return
+		}
+		stub.record(query)
+		_, _ = w.Write([]byte(`{"meta":[{"name":"t","type":"DateTime"},{"name":"v","type":"Float64"}],"data":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	ds := &ClickHouseDatasource{im: &fakeInstanceManager{settings: &DatasourceSettings{
+		Instance:   backend.DataSourceInstanceSettings{URL: srv.URL},
+		HTTPClient: srv.Client(),
+	}}}
+	return ds, stub
+}
+
+var timeFilterBounds = regexp.MustCompile(`toDateTime\((\d+)\)`)
+
+// queryRange extracts the [from, to] epochs the $timeFilter macro expanded to.
+func queryRange(t *testing.T, sql string) (int64, int64) {
+	t.Helper()
+	m := timeFilterBounds.FindAllStringSubmatch(sql, -1)
+	require.GreaterOrEqual(t, len(m), 2, "expected a time filter in %q", sql)
+	from, err := strconv.ParseInt(m[0][1], 10, 64)
+	require.NoError(t, err)
+	to, err := strconv.ParseInt(m[1][1], 10, 64)
+	require.NoError(t, err)
+	return from, to
+}
+
+// Full refresh mode used to query [session start, now] on every tick, so the range grew
+// for as long as the dashboard stayed open.
+func TestFullRefreshQueryRangeStaysBounded(t *testing.T) {
+	ds, stub := newStubDatasource(t)
+	sq := &streamQuery{
+		RefId:        "A",
+		Query:        "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t",
+		Table:        "test",
+		DateTimeCol:  "event_time",
+		DateTimeType: "DATETIME",
+		Interval:     "1s",
+		Format:       "time_series",
+	}
+
+	// Run over several 1s buckets: the window start must step with them, which is what
+	// distinguishes a sliding window from the fixed session start it replaced.
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 2500*time.Millisecond)
+	defer cancel()
+
+	require.NoError(t, ds.runFullRefreshLoop(ctx, &backend.RunStreamRequest{Path: "ds/uid/A"}, backend.NewStreamSender(&nopPacketSender{}), sq, 10*time.Minute, 1000, ticker, 1))
+
+	queries := stub.recorded()
+	require.GreaterOrEqual(t, len(queries), 3, "expected several ticks")
+
+	starts := map[int64]bool{}
+	for i, sql := range queries {
+		from, to := queryRange(t, sql)
+		require.Equal(t, int64(600), to-from, "tick %d: query range must stay windowSpan wide", i+1)
+		starts[from] = true
+	}
+	require.Greater(t, len(starts), 1, "window start must advance, not stay pinned to the session start")
 }

--- a/pkg/streaming_test.go
+++ b/pkg/streaming_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -298,10 +299,14 @@ func (f *fakeInstanceManager) Do(context.Context, backend.PluginContext, instanc
 	return nil
 }
 
-// clickhouseStub records the SQL it is asked to run and answers with an empty result set.
+// clickhouseStub records the SQL it is asked to run and answers with a scripted result set.
 type clickhouseStub struct {
 	mu      sync.Mutex
 	queries []string
+	// rowsFor returns the JSON rows for the n-th data query (1-based), empty for no rows.
+	rowsFor func(n int) string
+	// failAfter makes every data query past the n-th fail, 0 disables it.
+	failAfter int
 }
 
 func (s *clickhouseStub) record(q string) {
@@ -327,7 +332,22 @@ func newStubDatasource(t *testing.T) (*ClickHouseDatasource, *clickhouseStub) {
 			return
 		}
 		stub.record(query)
-		_, _ = w.Write([]byte(`{"meta":[{"name":"t","type":"DateTime"},{"name":"v","type":"Float64"}],"data":[]}`))
+
+		stub.mu.Lock()
+		n := len(stub.queries)
+		rowsFor, failAfter := stub.rowsFor, stub.failAfter
+		stub.mu.Unlock()
+
+		if failAfter > 0 && n > failAfter {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("boom"))
+			return
+		}
+		rows := ""
+		if rowsFor != nil {
+			rows = rowsFor(n)
+		}
+		_, _ = fmt.Fprintf(w, `{"meta":[{"name":"t","type":"DateTime"},{"name":"v","type":"Float64"}],"data":[%s]}`, rows)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -385,4 +405,176 @@ func TestFullRefreshQueryRangeStaysBounded(t *testing.T) {
 		starts[from] = true
 	}
 	require.Greater(t, len(starts), 1, "window start must advance, not stay pinned to the session start")
+}
+
+// capturingSender decodes the frames the stream published.
+type capturingSender struct {
+	mu     sync.Mutex
+	frames []*data.Frame
+}
+
+func (c *capturingSender) Send(p *backend.StreamPacket) error {
+	frame := &data.Frame{}
+	if err := frame.UnmarshalJSON(p.Data); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.frames = append(c.frames, frame)
+	return nil
+}
+
+func (c *capturingSender) captured() []*data.Frame {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]*data.Frame(nil), c.frames...)
+}
+
+func TestTrimAccumulatedFramesReportsChanges(t *testing.T) {
+	base := time.Unix(1785000000, 0)
+
+	t.Run("reports false when nothing is stale", func(t *testing.T) {
+		acc := map[string]*data.Frame{"s": accumFrame([]time.Time{base}, []float64{1})}
+		require.False(t, trimAccumulatedFrames(acc, base))
+	})
+
+	t.Run("reports false on an empty accumulator", func(t *testing.T) {
+		require.False(t, trimAccumulatedFrames(map[string]*data.Frame{}, base))
+	})
+
+	t.Run("reports true when rows are dropped", func(t *testing.T) {
+		acc := map[string]*data.Frame{"s": accumFrame(
+			[]time.Time{base, base.Add(time.Minute)}, []float64{1, 2},
+		)}
+		require.True(t, trimAccumulatedFrames(acc, base.Add(time.Minute)))
+	})
+
+	t.Run("reports true when a series is removed", func(t *testing.T) {
+		acc := map[string]*data.Frame{"s": accumFrame([]time.Time{base}, []float64{1})}
+		require.True(t, trimAccumulatedFrames(acc, base.Add(time.Hour)))
+	})
+}
+
+// Replace keeps the last frame on the client, so an emptied accumulator must be published
+// as a zero-row frame instead of silence.
+func TestSendAccumulatedFramesClearsThePanel(t *testing.T) {
+	base := time.Unix(1785000000, 0)
+	sq := &streamQuery{RefId: "A"}
+	ds := &ClickHouseDatasource{}
+
+	t.Run("sends a zero-row frame keeping the schema", func(t *testing.T) {
+		sink := &capturingSender{}
+		sender := backend.NewStreamSender(sink)
+
+		sent := ds.sendAccumulatedFrames(sender, map[string]*data.Frame{
+			"s": accumFrame([]time.Time{base}, []float64{1}),
+		}, sq, 1, nil)
+		require.NotNil(t, sent)
+
+		cleared := ds.sendAccumulatedFrames(sender, map[string]*data.Frame{}, sq, 2, sent)
+		require.NotNil(t, cleared)
+
+		frames := sink.captured()
+		require.Len(t, frames, 2)
+		require.Equal(t, 1, frames[0].Rows())
+		require.Equal(t, 0, frames[1].Rows(), "the panel must be cleared, not left on stale data")
+		require.Equal(t, len(frames[0].Fields), len(frames[1].Fields), "schema must survive")
+		require.Equal(t, frames[0].Fields[0].Name, frames[1].Fields[0].Name)
+	})
+
+	t.Run("stays silent when nothing was ever shown", func(t *testing.T) {
+		sink := &capturingSender{}
+
+		sent := ds.sendAccumulatedFrames(backend.NewStreamSender(sink), map[string]*data.Frame{}, sq, 1, nil)
+
+		require.Nil(t, sent)
+		require.Empty(t, sink.captured())
+	})
+}
+
+// The window keeps sliding while a source is silent: points that left it must still be
+// dropped and the client told, even though the query returned nothing new.
+func TestDeltaTrimsWhileSourceIsSilent(t *testing.T) {
+	ds, stub := newStubDatasource(t)
+	stub.rowsFor = func(n int) string {
+		if n == 1 {
+			return fmt.Sprintf(`{"t":"%s","v":1}`, time.Now().UTC().Format("2006-01-02 15:04:05"))
+		}
+		return "" // source goes silent
+	}
+
+	sq := &streamQuery{
+		RefId:        "A",
+		Query:        "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t",
+		Table:        "test",
+		DateTimeCol:  "event_time",
+		DateTimeType: "DATETIME",
+		Interval:     "1s",
+		Format:       "time_series",
+	}
+
+	sink := &capturingSender{}
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+
+	require.NoError(t, ds.runDeltaLoop(ctx, &backend.RunStreamRequest{Path: "ds/uid/A"},
+		backend.NewStreamSender(sink), sq, 2*time.Second, ticker, 1))
+
+	frames := sink.captured()
+	require.GreaterOrEqual(t, len(frames), 2, "expected the initial frame and a frame clearing it")
+	require.Equal(t, 1, frames[0].Rows(), "tick 1 must publish the row")
+
+	// A clearing frame keeps the schema and carries no rows. Error frames, which a
+	// cancelled last request can produce on shutdown, have no fields at all.
+	cleared := false
+	for _, f := range frames[1:] {
+		if f.Rows() == 0 && len(f.Fields) > 0 {
+			cleared = true
+		}
+	}
+	require.True(t, cleared, "the aged-out row must leave the panel")
+
+	// Republishing on every silent tick is ruled out by trimAccumulatedFrames reporting
+	// no change once the accumulator is empty, which is covered directly above.
+}
+
+func TestDeltaKeepsDataOnQueryError(t *testing.T) {
+	ds, stub := newStubDatasource(t)
+	stub.rowsFor = func(n int) string {
+		if n == 1 {
+			return fmt.Sprintf(`{"t":"%s","v":1}`, time.Now().UTC().Format("2006-01-02 15:04:05"))
+		}
+		return ""
+	}
+	stub.failAfter = 1
+
+	sq := &streamQuery{
+		RefId:        "A",
+		Query:        "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t",
+		Table:        "test",
+		DateTimeCol:  "event_time",
+		DateTimeType: "DATETIME",
+		Interval:     "1s",
+		Format:       "time_series",
+	}
+
+	sink := &capturingSender{}
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel()
+
+	require.NoError(t, ds.runDeltaLoop(ctx, &backend.RunStreamRequest{Path: "ds/uid/A"},
+		backend.NewStreamSender(sink), sq, time.Hour, ticker, 1))
+
+	frames := sink.captured()
+	require.GreaterOrEqual(t, len(frames), 2, "expected the data frame and at least one error frame")
+	require.Equal(t, 1, frames[0].Rows())
+
+	for i, f := range frames[1:] {
+		// Error frames carry no fields; a cleared accumulator would keep the data schema.
+		require.Empty(t, f.Fields, "frame %d: a failing query must not clear accumulated data", i+1)
+	}
 }


### PR DESCRIPTION
Review item 2: the dashboard time range was captured once at subscribe time and `TimeRange.To` was never read, so full refresh re-queried `[session start, now]` every tick and delta trimmed its accumulator against a cutoff that never advanced — the trim was effectively dead code, and memory and the payload sent to the browser grew for as long as the dashboard stayed open.

Derives the window width from the dashboard range and slides both edges, aligned to `$interval` buckets so identical ticks still dedup by fingerprint. Trimming now filters by predicate instead of cutting a prefix, which also drops series that left the window and rows appended out of order by backfill.

Panels now scroll once the window fills, matching the range shown in the time picker. Tests in `pkg/streaming_test.go`; each one fails against the pre-fix behaviour.

Stacked on #927 — merge that first.
