### PR TITLE
Improve test coverage: backend 56% -> 92%, frontend 39% -> 92%

### DIFF
--- a/.github/actions/testflows-suite/action.yml
+++ b/.github/actions/testflows-suite/action.yml
@@ -15,6 +15,10 @@ inputs:
   grafana-version:
     description: Grafana docker image tag to test against
     required: true
+  clickhouse-version:
+    description: ClickHouse docker image tag to test against
+    required: false
+    default: "latest"
   grafana-label:
     description: Matrix label used in artifact names (fixed or latest)
     required: true
@@ -54,6 +58,7 @@ runs:
       shell: bash
       env:
         GRAFANA_VERSION: ${{ inputs.grafana-version }}
+        CLICKHOUSE_VERSION: ${{ inputs.clickhouse-version }}
       run: |
         cd ./tests/testflows/
         SCENARIO_ARG=()

--- a/.github/workflows/testflows.yml
+++ b/.github/workflows/testflows.yml
@@ -134,6 +134,7 @@ jobs:
           suite-name: ${{ matrix.suite.name }}
           scenario: ${{ matrix.suite.scenario || '' }}
           grafana-version: "13.1.0"
+          clickhouse-version: "26.6"
           grafana-label: fixed
 
   # Informational leg: tracks the latest Grafana release. A failure marks the

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,20 +13,21 @@ module.exports = {
     'src/**/*.{ts,tsx}',
     '!src/**/*.{test,spec,jest}.{ts,tsx}',
     '!src/**/__mocks__/**',
+    '!src/spec/testUtils/**',
     '!src/**/*.d.ts',
     // Pure static data (autocomplete metadata): thousands of LOC, ~5 statements, no logic.
     '!src/views/QueryEditor/components/QueryTextEditor/editor/autocompletions/functions.ts',
     '!src/views/QueryEditor/components/QueryTextEditor/editor/constants/funcs.ts',
   ],
 
-  // Ratchet: floor measured 2026-07-14 on master (stmts 32.76 / branch 31.44 / func 21.75 / lines 32.33).
+  // Ratchet: floor measured 2026-08-10 (stmts 91.9 / branch 90.17 / func 82.18 / lines 92.68).
   // Raise these as coverage grows; never lower without a written justification.
   coverageThreshold: {
     global: {
-      statements: 32,
-      branches: 31,
-      functions: 21,
-      lines: 32,
+      statements: 90,
+      branches: 88,
+      functions: 80,
+      lines: 90,
     },
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "altinity-clickhouse-grafana",
-  "version": "3.4.12",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "altinity-clickhouse-grafana",
-      "version": "3.4.12",
+      "version": "3.5.0",
       "license": "MIT",
       "dependencies": {
         "@grafana/data": "13.1.0",
@@ -42,6 +42,7 @@
         "crypto-browserify": "^3.12.1",
         "css-loader": "^7.1.4",
         "eslint-webpack-plugin": "^5.0.3",
+        "fake-indexeddb": "^6.2.5",
         "fork-ts-checker-webpack-plugin": "^9.1.0",
         "glob": "^13.0.6",
         "identity-obj-proxy": "^3.0.0",
@@ -8761,6 +8762,16 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "crypto-browserify": "^3.12.1",
     "css-loader": "^7.1.4",
     "eslint-webpack-plugin": "^5.0.3",
+    "fake-indexeddb": "^6.2.5",
     "fork-ts-checker-webpack-plugin": "^9.1.0",
     "glob": "^13.0.6",
     "identity-obj-proxy": "^3.0.0",

--- a/pkg/client_test.go
+++ b/pkg/client_test.go
@@ -1,0 +1,281 @@
+package main
+
+import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/andybalholm/brotli"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/require"
+)
+
+const emptyResponseJSON = `{"meta":[],"data":[]}`
+
+// newTestClient spins up a ClickHouse HTTP stub and a client pointed at it.
+func newTestClient(t *testing.T, handler http.HandlerFunc, mutate func(*DatasourceSettings)) *ClickHouseClient {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	settings := &DatasourceSettings{
+		Instance:   backend.DataSourceInstanceSettings{URL: srv.URL},
+		HTTPClient: srv.Client(),
+	}
+	if mutate != nil {
+		mutate(settings)
+	}
+	return &ClickHouseClient{settings: settings}
+}
+
+func TestClientQueryGetPutsQueryInURL(t *testing.T) {
+	var gotMethod, gotQuery string
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotQuery = r.Method, r.URL.Query().Get("query")
+		_, _ = w.Write([]byte(emptyResponseJSON))
+	}, nil)
+
+	_, err := client.Query(context.Background(), "SELECT 1")
+
+	require.NoError(t, err)
+	require.Equal(t, "GET", gotMethod)
+	require.Equal(t, "SELECT 1", gotQuery)
+}
+
+func TestClientQueryPostPutsQueryInBody(t *testing.T) {
+	var gotMethod, gotBody string
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotMethod, gotBody = r.Method, string(body)
+		_, _ = w.Write([]byte(emptyResponseJSON))
+	}, func(s *DatasourceSettings) { s.UsePost = true })
+
+	_, err := client.Query(context.Background(), "SELECT 1")
+
+	require.NoError(t, err)
+	require.Equal(t, "POST", gotMethod)
+	require.Equal(t, "SELECT 1", gotBody)
+}
+
+func compress(t *testing.T, encoding string, payload []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	switch encoding {
+	case "gzip":
+		w := gzip.NewWriter(&buf)
+		_, err := w.Write(payload)
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+	case "deflate":
+		w, err := flate.NewWriter(&buf, flate.DefaultCompression)
+		require.NoError(t, err)
+		_, err = w.Write(payload)
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+	case "br":
+		w := brotli.NewWriter(&buf)
+		_, err := w.Write(payload)
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+	case "zstd":
+		w, err := zstd.NewWriter(&buf)
+		require.NoError(t, err)
+		_, err = w.Write(payload)
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+	}
+	return buf.Bytes()
+}
+
+func TestClientQueryDecodesCompressedResponses(t *testing.T) {
+	for _, encoding := range []string{"gzip", "deflate", "br", "zstd"} {
+		t.Run(encoding, func(t *testing.T) {
+			client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, encoding, r.Header.Get("Accept-Encoding"))
+				require.Equal(t, "1", r.URL.Query().Get("enable_http_compression"))
+				w.Header().Set("Content-Encoding", encoding)
+				_, _ = w.Write(compress(t, encoding, []byte(`{"meta":[],"data":[{"x":1}]}`)))
+			}, func(s *DatasourceSettings) {
+				s.UseCompression = true
+				s.CompressionType = encoding
+			})
+
+			resp, err := client.Query(context.Background(), "SELECT 1")
+
+			require.NoError(t, err)
+			require.Len(t, resp.Data, 1)
+		})
+	}
+}
+
+func TestClientQueryUnknownCompressionTypeIsIgnored(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		// The transport adds its own Accept-Encoding; the client must not opt in itself.
+		require.Empty(t, r.URL.Query().Get("enable_http_compression"))
+		_, _ = w.Write([]byte(emptyResponseJSON))
+	}, func(s *DatasourceSettings) {
+		s.UseCompression = true
+		s.CompressionType = "lz77"
+	})
+
+	_, err := client.Query(context.Background(), "SELECT 1")
+	require.NoError(t, err)
+}
+
+func TestClientQueryAuthHeaders(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*DatasourceSettings)
+		check  func(*testing.T, *http.Request)
+	}{
+		{
+			"basic auth uses the secure password",
+			func(s *DatasourceSettings) {
+				s.Instance.BasicAuthEnabled = true
+				s.Instance.BasicAuthUser = "user"
+				s.Instance.DecryptedSecureJSONData = map[string]string{"basicAuthPassword": "secret"}
+			},
+			func(t *testing.T, r *http.Request) {
+				user, pass, ok := r.BasicAuth()
+				require.True(t, ok)
+				require.Equal(t, "user", user)
+				require.Equal(t, "secret", pass)
+			},
+		},
+		{
+			"yandex ssl certificate auth",
+			func(s *DatasourceSettings) {
+				s.UseYandexCloudAuthorization = true
+				s.XHeaderUser = "yc-user"
+				s.XClickHouseSSLCertificateAuth = true
+			},
+			func(t *testing.T, r *http.Request) {
+				require.Equal(t, "yc-user", r.Header.Get("X-ClickHouse-User"))
+				require.Equal(t, "on", r.Header.Get("X-ClickHouse-SSL-Certificate-Auth"))
+				require.Empty(t, r.Header.Get("X-ClickHouse-Key"))
+			},
+		},
+		{
+			"yandex plain key",
+			func(s *DatasourceSettings) {
+				s.UseYandexCloudAuthorization = true
+				s.XHeaderUser = "yc-user"
+				s.XHeaderKey = "plain-key"
+			},
+			func(t *testing.T, r *http.Request) {
+				require.Equal(t, "plain-key", r.Header.Get("X-ClickHouse-Key"))
+			},
+		},
+		{
+			"yandex secure key overrides the plain one",
+			func(s *DatasourceSettings) {
+				s.UseYandexCloudAuthorization = true
+				s.XHeaderKey = "plain-key"
+				s.Instance.DecryptedSecureJSONData = map[string]string{"xHeaderKey": "secure-key"}
+			},
+			func(t *testing.T, r *http.Request) {
+				require.Equal(t, "secure-key", r.Header.Get("X-ClickHouse-Key"))
+			},
+		},
+		{
+			"custom headers",
+			func(s *DatasourceSettings) {
+				s.CustomHeaders = map[string]string{"X-Custom": "yes"}
+			},
+			func(t *testing.T, r *http.Request) {
+				require.Equal(t, "yes", r.Header.Get("X-Custom"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got *http.Request
+			client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				got = r.Clone(context.Background())
+				_, _ = w.Write([]byte(emptyResponseJSON))
+			}, tt.mutate)
+
+			_, err := client.Query(context.Background(), "SELECT 1")
+
+			require.NoError(t, err)
+			tt.check(t, got)
+		})
+	}
+}
+
+func TestClientQueryErrors(t *testing.T) {
+	t.Run("unparsable datasource url", func(t *testing.T) {
+		client := &ClickHouseClient{settings: &DatasourceSettings{
+			Instance: backend.DataSourceInstanceSettings{URL: "://bad"},
+		}}
+		_, err := client.Query(context.Background(), "SELECT 1")
+		require.ErrorContains(t, err, "unable to parse clickhouse datasource url")
+	})
+
+	t.Run("nil http client", func(t *testing.T) {
+		client := &ClickHouseClient{settings: &DatasourceSettings{
+			Instance: backend.DataSourceInstanceSettings{URL: "http://localhost:8123"},
+		}}
+		_, err := client.Query(context.Background(), "SELECT 1")
+		require.ErrorContains(t, err, "http client is not initialized")
+	})
+
+	t.Run("non-200 returns the body as the error", func(t *testing.T) {
+		client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("Code: 62. DB::Exception: Syntax error"))
+		}, nil)
+		_, err := client.Query(context.Background(), "SELECT nope")
+		require.ErrorContains(t, err, "Syntax error")
+	})
+
+	t.Run("invalid json body", func(t *testing.T) {
+		client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("{not json"))
+		}, nil)
+		_, err := client.Query(context.Background(), "SELECT 1")
+		require.ErrorContains(t, err, "unable to parse json")
+	})
+
+	t.Run("corrupt gzip body", func(t *testing.T) {
+		client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Encoding", "gzip")
+			_, _ = w.Write([]byte("definitely not gzip"))
+		}, func(s *DatasourceSettings) {
+			s.UseCompression = true
+			s.CompressionType = "gzip"
+		})
+		_, err := client.Query(context.Background(), "SELECT 1")
+		require.ErrorContains(t, err, "GZIP reader")
+	})
+}
+
+func TestFetchTimeZone(t *testing.T) {
+	t.Run("returns the server timezone", func(t *testing.T) {
+		client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"meta":[{"name":"timezone()","type":"String"}],"data":[{"timezone()":"Europe/Moscow"}]}`))
+		}, nil)
+
+		tz := client.FetchTimeZone(context.Background())
+
+		loc, err := time.LoadLocation("Europe/Moscow")
+		require.NoError(t, err)
+		require.Equal(t, loc.String(), tz.String())
+	})
+
+	t.Run("falls back to UTC on error", func(t *testing.T) {
+		client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}, nil)
+
+		require.Equal(t, time.UTC, client.FetchTimeZone(context.Background()))
+	})
+}

--- a/pkg/datasource_settings_test.go
+++ b/pkg/datasource_settings_test.go
@@ -55,3 +55,12 @@ func TestNewDatasourceSettings(t *testing.T) {
 	require.Equal(t, "value1", dsSettings.CustomHeaders["header1"])
 	require.Equal(t, "value2", dsSettings.CustomHeaders["header2"])
 }
+
+func TestNewDatasourceSettingsMissingSecureHeader(t *testing.T) {
+	settings := backend.DataSourceInstanceSettings{
+		JSONData:                []byte(`{"httpHeaderName1": "X-Custom"}`),
+		DecryptedSecureJSONData: map[string]string{},
+	}
+	_, err := NewDatasourceSettings(context.Background(), settings)
+	require.ErrorContains(t, err, "httpHeaderValue1 not present in settings.DecryptedSecureJSONData")
+}

--- a/pkg/datasource_test.go
+++ b/pkg/datasource_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
+	"github.com/stretchr/testify/require"
+)
+
+type failingInstanceManager struct{}
+
+func (f *failingInstanceManager) Get(context.Context, backend.PluginContext) (instancemgmt.Instance, error) {
+	return nil, errors.New("instance manager down")
+}
+
+func (f *failingInstanceManager) Do(context.Context, backend.PluginContext, instancemgmt.InstanceCallbackFunc) error {
+	return nil
+}
+
+func dataQuery(refID, jsonBody string) backend.DataQuery {
+	return backend.DataQuery{
+		RefID: refID,
+		JSON:  []byte(jsonBody),
+		TimeRange: backend.TimeRange{
+			From: time.Now().Add(-time.Hour),
+			To:   time.Now(),
+		},
+	}
+}
+
+func TestQueryDataEvalQuery(t *testing.T) {
+	ds, stub := newStubDatasource(t)
+
+	resp, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
+		Queries: []backend.DataQuery{dataQuery("A",
+			`{"refId":"A","query":"SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t","table":"test","dateTimeColDataType":"event_time","dateTimeType":"DATETIME","interval":"1s","format":"time_series"}`)},
+	})
+
+	require.NoError(t, err)
+	require.NoError(t, resp.Responses["A"].Error)
+	require.Len(t, stub.recorded(), 1)
+	require.Contains(t, stub.recorded()[0], "FROM test")
+}
+
+// EvalQuery unmarshal fails on the bogus extrapolate, so the raw Query path must take over.
+func TestQueryDataFallsBackToRawQuery(t *testing.T) {
+	ds, stub := newStubDatasource(t)
+
+	resp, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
+		Queries: []backend.DataQuery{dataQuery("B", `{"refId":"B","rawQuery":"SELECT 1","extrapolate":"not-a-bool"}`)},
+	})
+
+	require.NoError(t, err)
+	require.NoError(t, resp.Responses["B"].Error)
+	require.Len(t, stub.recorded(), 1)
+	require.Contains(t, stub.recorded()[0], "SELECT 1")
+}
+
+func TestQueryDataRejectsUnparsableJSON(t *testing.T) {
+	ds, _ := newStubDatasource(t)
+
+	_, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
+		Queries: []backend.DataQuery{dataQuery("C", `{not json`)},
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unable to parse json")
+}
+
+func TestQueryDataMultipleQueriesWithRuleUid(t *testing.T) {
+	ds, stub := newStubDatasource(t)
+
+	resp, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
+		Headers: map[string]string{"X-Rule-Uid": "rule-42"},
+		Queries: []backend.DataQuery{
+			dataQuery("A", `{"refId":"A","query":"SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t","table":"test","dateTimeColDataType":"event_time","dateTimeType":"DATETIME","interval":"1s","format":"time_series"}`),
+			dataQuery("B", `{"refId":"B","rawQuery":"SELECT 2","extrapolate":"not-a-bool"}`),
+		},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, resp.Responses, 2)
+	require.NoError(t, resp.Responses["A"].Error)
+	require.NoError(t, resp.Responses["B"].Error)
+	require.Len(t, stub.recorded(), 2)
+}
+
+// A macro expansion failure must surface as the refId's error, covering evalQuery's error path.
+func TestQueryDataReportsMacroError(t *testing.T) {
+	ds, _ := newStubDatasource(t)
+
+	resp, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
+		Queries: []backend.DataQuery{dataQuery("A",
+			`{"refId":"A","query":"SELECT $timeSeries as t FROM $table WHERE $timeFilter","table":"test","dateTimeColDataType":"event_time","dateTimeType":"DATETIME","interval":"banana"}`)},
+	})
+
+	require.NoError(t, err)
+	require.ErrorContains(t, resp.Responses["A"].Error, "interval")
+}
+
+func TestQueryDataReportsQueryError(t *testing.T) {
+	ds := &ClickHouseDatasource{im: &fakeInstanceManager{settings: &DatasourceSettings{
+		Instance:   backend.DataSourceInstanceSettings{URL: "://bad"},
+		HTTPClient: http.DefaultClient,
+	}}}
+
+	resp, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
+		Queries: []backend.DataQuery{dataQuery("A", `{"refId":"A","rawQuery":"SELECT 1","extrapolate":"not-a-bool"}`)},
+	})
+
+	require.NoError(t, err, "a failing query becomes a per-refId error, not a request error")
+	require.Error(t, resp.Responses["A"].Error)
+}
+
+func TestCheckHealth(t *testing.T) {
+	t.Run("healthy backend", func(t *testing.T) {
+		ds, _ := newStubDatasource(t)
+
+		res, err := ds.CheckHealth(context.Background(), &backend.CheckHealthRequest{})
+
+		require.NoError(t, err)
+		require.Equal(t, backend.HealthStatusOk, res.Status)
+		require.Equal(t, "OK", res.Message)
+	})
+
+	t.Run("unreachable backend", func(t *testing.T) {
+		ds := &ClickHouseDatasource{im: &fakeInstanceManager{settings: &DatasourceSettings{
+			Instance:   backend.DataSourceInstanceSettings{URL: "http://127.0.0.1:1"},
+			HTTPClient: &http.Client{Timeout: time.Second},
+		}}}
+
+		res, err := ds.CheckHealth(context.Background(), &backend.CheckHealthRequest{})
+
+		require.Error(t, err)
+		require.Equal(t, backend.HealthStatusError, res.Status)
+	})
+
+	t.Run("broken instance manager", func(t *testing.T) {
+		ds := &ClickHouseDatasource{im: &failingInstanceManager{}}
+
+		res, err := ds.CheckHealth(context.Background(), &backend.CheckHealthRequest{})
+
+		require.Error(t, err)
+		require.Equal(t, backend.HealthStatusError, res.Status)
+		require.Contains(t, res.Message, "instance manager down")
+	})
+}

--- a/pkg/eval/eval_query_test.go
+++ b/pkg/eval/eval_query_test.go
@@ -2580,3 +2580,292 @@ func TestEvalQueryTimeStamp64AndFloatColumnsSupport(t *testing.T) {
 		})
 	}
 }
+
+// TestApplyMacrosAndTimeRangeToQuery runs the full pipeline for each macro to cover applyMacros dispatch
+func TestApplyMacrosAndTimeRangeToQuery(t *testing.T) {
+	from := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2022, 1, 2, 0, 0, 0, 0, time.UTC)
+	testCases := []struct {
+		query    string
+		expected string
+	}{
+		{
+			"SELECT $timeSeries AS t, count() FROM $table WHERE $timeFilter GROUP BY t",
+			"SELECT (intDiv(toUInt32(dt), 864) * 864) * 1000 AS t, count() FROM db.tbl WHERE dt >= toDateTime(1640995200) AND dt <= toDateTime(1641081600) GROUP BY t",
+		},
+		{
+			"$columns(a, sum(x) AS c) FROM $table",
+			"SELECT t, groupArray((a, c)) AS groupArr FROM ( SELECT (intDiv(toUInt32(dt), 864) * 864) * 1000 AS t, a, sum(x) AS c FROM db.tbl WHERE dt >= toDateTime(1640995200) AND dt <= toDateTime(1641081600) GROUP BY t, a ORDER BY t, a) GROUP BY t ORDER BY t",
+		},
+		{
+			"$columnsMs(a, sum(x) AS c) FROM $table",
+			"SELECT t, groupArray((a, c)) AS groupArr FROM ( SELECT (intDiv(toUInt32(dt) * 1000, 864000) * 864000) AS t, a, sum(x) AS c FROM db.tbl WHERE dt >= toDateTime(1640995200000/1000) AND dt <= toDateTime(1641081600000/1000) GROUP BY t, a ORDER BY t, a) GROUP BY t ORDER BY t",
+		},
+		{
+			"$lttb(auto, x, y) FROM $table",
+			"SELECT `lttb_result.1` AS x, `lttb_result.2` AS y FROM (\n  SELECT untuple(arrayJoin(lttb(toUInt64( (1641081600 - 1640995200) / 864 ))(x, y))) AS lttb_result FROM db.tbl WHERE dt >= toDateTime(1640995200) AND dt <= toDateTime(1641081600)\n) ORDER BY x",
+		},
+		{
+			"$lttbMs(auto, x, y) FROM $table",
+			"SELECT `lttb_result.1` AS x, `lttb_result.2` AS y FROM (\n  SELECT untuple(arrayJoin(lttb(toUInt64( (1641081600000 - 1640995200000) / 864000 ))(x, y))) AS lttb_result FROM db.tbl WHERE dt >= toDateTime(1640995200000/1000) AND dt <= toDateTime(1641081600000/1000)\n) ORDER BY x",
+		},
+		{
+			"$rate(cnt AS c) FROM $table",
+			"SELECT t, c/runningDifference(t/1000) cRate FROM ( SELECT (intDiv(toUInt32(dt), 864) * 864) * 1000 AS t, cnt AS c FROM db.tbl WHERE dt >= toDateTime(1640995200) AND dt <= toDateTime(1641081600)\n GROUP BY t\n ORDER BY t)",
+		},
+		{
+			"$perSecond(a) FROM $table",
+			"SELECT t, if(runningDifference(max_0) < 0, nan, runningDifference(max_0) / runningDifference(t/1000)) AS max_0_PerSecond FROM ( SELECT (intDiv(toUInt32(dt), 864) * 864) * 1000 AS t, max(a) AS max_0 FROM db.tbl WHERE dt >= toDateTime(1640995200) AND dt <= toDateTime(1641081600) GROUP BY t ORDER BY t)",
+		},
+		{
+			"$perSecondColumns(a, b) FROM $table",
+			"SELECT t, groupArray((perSecondColumns, max_0_PerSecond)) AS groupArr FROM ( SELECT t, perSecondColumns, if(runningDifference(max_0) < 0 OR neighbor(perSecondColumns,-1,perSecondColumns) != perSecondColumns, nan, runningDifference(max_0) / runningDifference(t/1000)) AS max_0_PerSecond FROM ( SELECT (intDiv(toUInt32(dt), 864) * 864) * 1000 AS t, a AS perSecondColumns, max(b) AS max_0 FROM db.tbl WHERE dt >= toDateTime(1640995200) AND dt <= toDateTime(1641081600) GROUP BY t, perSecondColumns ORDER BY perSecondColumns, t)) GROUP BY t ORDER BY t",
+		},
+		{
+			"$perSecondColumnsAggregated(dc, concat(dc,i) AS dci, sum, tx AS t2) FROM $table",
+			"SELECT t, dc, sum(t2PerSecond) AS t2PerSecondAgg FROM (  SELECT t, dc, dci, if(runningDifference(t2) < 0 OR neighbor(dci,-1,dci) != dci, nan, runningDifference(t2) / runningDifference(t / 1000)) AS t2PerSecond  FROM (   SELECT (intDiv(toUInt32(dt), 864) * 864) * 1000 AS t, dc, concat(dc, i) AS dci, max(tx) AS t2   FROM db.tbl WHERE dt >= toDateTime(1640995200) AND dt <= toDateTime(1641081600)   GROUP BY dc, dci, t    ORDER BY dc, dci, t  ) ) GROUP BY dc, t ORDER BY dc, t",
+		},
+		{
+			"$rateColumns(a, sum(b) AS c) FROM $table",
+			"SELECT t, arrayMap(a -> (a.1, a.2/runningDifference( t/1000 )), groupArr) FROM (SELECT t, groupArray((a, c)) AS groupArr FROM ( SELECT (intDiv(toUInt32(dt), 864) * 864) * 1000 AS t, a, sum(b) AS c FROM db.tbl WHERE dt >= toDateTime(1640995200) AND dt <= toDateTime(1641081600) GROUP BY t, a ORDER BY t, a) GROUP BY t ORDER BY t)",
+		},
+		{
+			"$rateColumnsAggregated(dc, concat(dc,i) AS dci, sum, tx AS t2) FROM $table",
+			"SELECT t, dc, sum(t2Rate) AS t2RateAgg FROM (  SELECT t, dc, dci, t2 / runningDifference(t / 1000) AS t2Rate  FROM (   SELECT (intDiv(toUInt32(dt), 864) * 864) * 1000 AS t, dc, concat(dc, i) AS dci, max(tx) AS t2   FROM db.tbl WHERE dt >= toDateTime(1640995200) AND dt <= toDateTime(1641081600)   GROUP BY dc, dci, t    ORDER BY dc, dci, t  ) ) GROUP BY dc, t ORDER BY dc, t",
+		},
+		{
+			"$deltaColumnsAggregated(dc, concat(dc,i) AS dci, sum, tx AS t2) FROM $table",
+			"SELECT t, dc, sum(t2Delta) AS t2DeltaAgg FROM (  SELECT t, dc, dci, if(neighbor(dci,-1,dci) != dci, 0, runningDifference(t2) / 1) AS t2Delta  FROM (   SELECT (intDiv(toUInt32(dt), 864) * 864) * 1000 AS t, dc, concat(dc, i) AS dci, max(tx) AS t2   FROM db.tbl WHERE dt >= toDateTime(1640995200) AND dt <= toDateTime(1641081600)   GROUP BY dc, dci, t    ORDER BY dc, dci, t  ) ) GROUP BY dc, t ORDER BY dc, t",
+		},
+		{
+			"$increaseColumnsAggregated(dc, concat(dc,i) AS dci, sum, tx AS t2) FROM $table",
+			"SELECT t, dc, sum(t2Increase) AS t2IncreaseAgg FROM (  SELECT t, dc, dci, if(runningDifference(t2) < 0 OR neighbor(dci,-1,dci) != dci, nan, runningDifference(t2) / 1) AS t2Increase  FROM (   SELECT (intDiv(toUInt32(dt), 864) * 864) * 1000 AS t, dc, concat(dc, i) AS dci, max(tx) AS t2   FROM db.tbl WHERE dt >= toDateTime(1640995200) AND dt <= toDateTime(1641081600)   GROUP BY dc, dci, t    ORDER BY dc, dci, t  ) ) GROUP BY dc, t ORDER BY dc, t",
+		},
+		{
+			"$delta(a) FROM $table",
+			"SELECT t, runningDifference(max_0) AS max_0_Delta FROM ( SELECT (intDiv(toUInt32(dt), 864) * 864) * 1000 AS t, max(a) AS max_0 FROM db.tbl WHERE dt >= toDateTime(1640995200) AND dt <= toDateTime(1641081600) GROUP BY t ORDER BY t)",
+		},
+		{
+			"$deltaColumns(a, b) FROM $table",
+			"SELECT t, groupArray((deltaColumns, max_0_Delta)) AS groupArr FROM ( SELECT t, deltaColumns, if(neighbor(deltaColumns,-1,deltaColumns) != deltaColumns, 0, runningDifference(max_0)) AS max_0_Delta FROM ( SELECT (intDiv(toUInt32(dt), 864) * 864) * 1000 AS t, a AS deltaColumns, max(b) AS max_0 FROM db.tbl WHERE dt >= toDateTime(1640995200) AND dt <= toDateTime(1641081600) GROUP BY t, deltaColumns ORDER BY deltaColumns, t)) GROUP BY t ORDER BY t",
+		},
+		{
+			"$increase(a) FROM $table",
+			"SELECT t, if(runningDifference(max_0) < 0, 0, runningDifference(max_0)) AS max_0_Increase FROM ( SELECT (intDiv(toUInt32(dt), 864) * 864) * 1000 AS t, max(a) AS max_0 FROM db.tbl WHERE dt >= toDateTime(1640995200) AND dt <= toDateTime(1641081600) GROUP BY t ORDER BY t)",
+		},
+		{
+			"$increaseColumns(a, b) FROM $table",
+			"SELECT t, groupArray((increaseColumns, max_0_Increase)) AS groupArr FROM ( SELECT t, increaseColumns, if(runningDifference(max_0) < 0 OR neighbor(increaseColumns,-1,increaseColumns) != increaseColumns, 0, runningDifference(max_0)) AS max_0_Increase FROM ( SELECT (intDiv(toUInt32(dt), 864) * 864) * 1000 AS t, a AS increaseColumns, max(b) AS max_0 FROM db.tbl WHERE dt >= toDateTime(1640995200) AND dt <= toDateTime(1641081600) GROUP BY t, increaseColumns ORDER BY increaseColumns, t)) GROUP BY t ORDER BY t",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.query, func(t *testing.T) {
+			q := EvalQuery{
+				Query:         tc.query,
+				Database:      "db",
+				Table:         "tbl",
+				DateTimeCol:   "dt",
+				DateTimeType:  "DATETIME",
+				From:          from,
+				To:            to,
+				MaxDataPoints: 100,
+			}
+			actual, err := q.ApplyMacrosAndTimeRangeToQuery()
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestApplyMacrosAndTimeRangeToQueryErrors(t *testing.T) {
+	from := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2022, 1, 2, 0, 0, 0, 0, time.UTC)
+	testCases := []struct {
+		name        string
+		q           EvalQuery
+		expectedErr string
+	}{
+		{"invalid interval", EvalQuery{Query: "SELECT 1", Interval: "xyz", From: from, To: to}, "expected number at position 0 in interval 'xyz'"},
+		{"invalid round", EvalQuery{Query: "SELECT 1", Round: "1z", From: from, To: to}, `unknown unit "z"`},
+		{"AST parse error", EvalQuery{Query: "SELECT x FROM tbl WHERE a IN", From: from, To: to}, "parse AST error"},
+		{"macro args error", EvalQuery{Query: "$columns(a) FROM tbl", From: from, To: to}, "applyMacros error: amount of arguments must equal 2 for $columns func"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.q.ApplyMacrosAndTimeRangeToQuery()
+			require.ErrorContains(t, err, tc.expectedErr)
+		})
+	}
+}
+
+// covers Round == "$step" and IntervalFactor > 1
+func TestApplyMacrosAndTimeRangeToQueryRoundStepAndIntervalFactor(t *testing.T) {
+	q := EvalQuery{
+		Query:          "SELECT $from, $to, $interval, $__interval_ms",
+		Database:       "db",
+		Table:          "tbl",
+		DateTimeCol:    "dt",
+		DateTimeType:   "DATETIME",
+		Interval:       "30s",
+		IntervalFactor: 2,
+		Round:          "$step",
+		From:           time.Date(2022, 1, 1, 0, 0, 13, 0, time.UTC),
+		To:             time.Date(2022, 1, 2, 0, 0, 17, 0, time.UTC),
+	}
+	actual, err := q.ApplyMacrosAndTimeRangeToQuery()
+	require.NoError(t, err)
+	require.Equal(t, "SELECT 1640995200, 1641081600, 60, 60000", actual)
+}
+
+func TestAddMetadata(t *testing.T) {
+	s := NewScanner("")
+	require.Equal(t,
+		"/* grafana dashboard=$__dashboard, user=$__user */\nSELECT 1",
+		s.AddMetadata("SELECT 1", &EvalQuery{FrontendDatasource: true}))
+	require.Equal(t,
+		"/* grafana dashboard=$__dashboard, user=bob */\nSELECT 1",
+		s.AddMetadata("SELECT 1", &EvalQuery{FrontendDatasource: true, MetadataUserLogin: "bob"}))
+	require.Equal(t,
+		"/* grafana alerts rule=r1 query=A */ SELECT 1",
+		s.AddMetadata("SELECT 1", &EvalQuery{RuleUid: "r1", RefId: "A"}))
+}
+
+func TestScannerFormat(t *testing.T) {
+	testCases := []struct {
+		name     string
+		query    string
+		expected string
+	}{
+		{
+			"select with aliases group by having order by limit format",
+			"SELECT a, b AS bb FROM db.tbl AS x WHERE x > 1 GROUP BY a HAVING cnt > 0 ORDER BY a LIMIT 10,20 FORMAT JSON",
+			"SELECT\n    a,\n    b AS bb\nFROM db.tbl AS x\n\nWHERE x > 1\n\nGROUP BY a\n\nHAVING cnt > 0\n\nORDER BY a\n\nLIMIT\n    10,\n    20\nFORMAT JSON\n",
+		},
+		{
+			"with and prewhere",
+			"WITH 1 AS one SELECT one FROM tbl PREWHERE a = 1 WHERE b = 2",
+			"WITH 1 AS one\nSELECT one\n\nFROM tbl\n\nPREWHERE a = 1\n\nWHERE b = 2\n",
+		},
+		{
+			"union all",
+			"SELECT 1 UNION ALL SELECT 2",
+			"SELECT 1\n\n\nUNION ALL\n\nSELECT 2\n",
+		},
+		{
+			"$rate",
+			"$rate(cnt c) FROM tbl",
+			"$rate( cnt c\n)SELECT\nFROM tbl\n",
+		},
+		{
+			"$perSecond",
+			"$perSecond(a) FROM tbl",
+			"$perSecond( a\n)SELECT\nFROM tbl\n",
+		},
+		{
+			"$perSecondColumns",
+			"$perSecondColumns(a, b) FROM tbl",
+			"$perSecondColumns(\n    a,\n    b)SELECT\nFROM tbl\n",
+		},
+		{
+			"$columns",
+			"$columns(a, sum(b) c) FROM tbl",
+			"$columns(\n    a,\n    sum(b) c)SELECT\nFROM tbl\n",
+		},
+		{
+			"$columnsMs",
+			"$columnsMs(a, sum(b) c) FROM tbl",
+			"$columnsMs(\n    a,\n    sum(b) c)SELECT\nFROM tbl\n",
+		},
+		{
+			"$rateColumns",
+			"$rateColumns(a, sum(b) c) FROM tbl",
+			"$rateColumns(\n    a,\n    sum(b) c)SELECT\nFROM tbl\n",
+		},
+		{
+			"$rateColumnsAggregated",
+			"$rateColumnsAggregated(dc, concat(dc,i) AS dci, sum, tx AS t2, sum, max(rx) AS r2) FROM tbl",
+			"$rateColumnsAggregated(\n    dc,\n    concat(dc, i) AS dci,\n    sum,\n    tx AS t2,\n    sum,\n    max(rx) AS r2)SELECT\nFROM tbl\n",
+		},
+		{
+			"$lttb",
+			"$lttb(auto, x, y) FROM tbl",
+			"$lttb(\n    auto,\n    x,\n    y)SELECT\nFROM tbl\n",
+		},
+		{
+			"join using",
+			"SELECT * FROM a ANY LEFT JOIN b USING (x)",
+			"SELECT *\n\nFROM a\n\nANY LEFT JOIN\n(\n b\n\n)  USING  x\n",
+		},
+		{
+			"join on",
+			"SELECT * FROM a LEFT JOIN b ON a.x = b.x",
+			"SELECT *\n\nFROM a\n\nLEFT JOIN\n(\n b\n\n)  ON  a.x=b.x\n",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewScanner(tc.query)
+			actual, err := s.Format()
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+
+	s := NewScanner("SELECT x FROM tbl WHERE a IN")
+	_, err := s.Format()
+	require.ErrorContains(t, err, "wrong `IN` signature")
+}
+
+func TestBetweenSquareBraces(t *testing.T) {
+	require.Equal(t, "a,b", betweenSquareBraces("a,b] rest"))
+	require.Equal(t, "[x,y],z", betweenSquareBraces("[x,y],z] rest"))
+	require.Equal(t, "", betweenSquareBraces("no close"))
+	require.Equal(t, "", betweenSquareBraces("]"))
+}
+
+func TestNewEvalQuery(t *testing.T) {
+	type evalQueryRequest struct {
+		RefId                  string
+		RuleUid                string
+		RawQuery               bool
+		Query                  string
+		DateTimeColDataType    string
+		DateColDataType        string
+		DateTimeType           string
+		Extrapolate            bool
+		SkipComments           bool
+		AddMetadata            bool
+		Format                 string
+		Round                  string
+		IntervalFactor         int
+		Interval               string
+		Database               string
+		Table                  string
+		MaxDataPoints          int64
+		FrontendDatasource     bool
+		UseWindowFuncForMacros bool
+		MetadataUserLogin      string
+	}
+	req := evalQueryRequest{
+		RefId: "A", RuleUid: "r1", RawQuery: true, Query: "SELECT 1",
+		DateTimeColDataType: "dt", DateColDataType: "d", DateTimeType: "DATETIME64",
+		Extrapolate: true, SkipComments: true, AddMetadata: true,
+		Format: "time_series", Round: "1m", IntervalFactor: 2, Interval: "30s",
+		Database: "db", Table: "tbl", MaxDataPoints: 42,
+		FrontendDatasource: true, UseWindowFuncForMacros: true, MetadataUserLogin: "bob",
+	}
+	from := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2022, 1, 2, 0, 0, 0, 0, time.UTC)
+	expected := EvalQuery{
+		RefId: "A", RuleUid: "r1", RawQuery: true, Query: "SELECT 1",
+		DateTimeCol: "dt", DateCol: "d", DateTimeType: "DATETIME64",
+		Extrapolate: true, SkipComments: true, AddMetadata: true,
+		Format: "time_series", Round: "1m", IntervalFactor: 2, Interval: "30s",
+		Database: "db", Table: "tbl", MaxDataPoints: 42,
+		FrontendDatasource: true, UseWindowFuncForMacros: true, MetadataUserLogin: "bob",
+		From: from, To: to,
+	}
+	require.Equal(t, expected, NewEvalQuery(req, from, to))
+	// pointer requests are dereferenced
+	require.Equal(t, expected, NewEvalQuery(&req, from, to))
+}

--- a/pkg/parser_test.go
+++ b/pkg/parser_test.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/stretchr/testify/require"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func TestParseTimeZone(t *testing.T) {
+	require.Equal(t, "Europe/Moscow", ParseTimeZone("Europe/Moscow").String())
+	require.Equal(t, time.UTC, ParseTimeZone("Not/AZone"))
+}
+
+// Documents the current slicing behavior, including the off-by-one on quoted names.
+func TestExtractTimeZoneNameFromFieldType(t *testing.T) {
+	tests := []struct {
+		fieldType string
+		want      string
+	}{
+		{"DateTime('UTC')", "TC"},
+		{"DateTime(' UTC')", "UTC"},
+		{"Date(' UTC')", "UTC"},
+		{"DateTime64('3', 'UTC')", "UTC"},
+		{"DateTime64(3,'Europe/Moscow')", ""},
+		{"Array(DateTime(' UTC'))", "UTC"},
+		{"Array(String)", ""},
+		{"DateTime", ""},
+		{"String", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.fieldType, func(t *testing.T) {
+			require.Equal(t, tt.want, extractTimeZoneNameFromFieldType(tt.fieldType))
+		})
+	}
+}
+
+func TestFetchTimeZoneFromFieldType(t *testing.T) {
+	server := ParseTimeZone("Europe/Moscow")
+	require.Equal(t, time.UTC, fetchTimeZoneFromFieldType("DateTime(' UTC')", server))
+	require.Equal(t, server, fetchTimeZoneFromFieldType("DateTime", server))
+}
+
+func TestIsValueSafeForFloat64(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     interface{}
+		fieldType string
+		want      bool
+	}{
+		{"nil", nil, "UInt64", true},
+		{"uint64 max safe", json.Number("9007199254740991"), "UInt64", true},
+		{"uint64 unsafe", json.Number("9007199254740992"), "UInt64", false},
+		{"uint64 string", "42", "UInt64", true},
+		{"uint64 garbage", "abc", "UInt64", true},
+		{"int64 min safe", "-9007199254740991", "Int64", true},
+		{"int64 negative unsafe", "-9007199254740992", "Int64", false},
+		{"int64 positive unsafe", json.Number("9007199254740992"), "Int64", false},
+		{"int64 garbage", "abc", "Int64", true},
+		{"nullable uint64 unsafe", json.Number("18446744073709551615"), "Nullable(UInt64)", false},
+		{"lowcardinality nullable int64", json.Number("1"), "LowCardinality(Nullable(Int64))", true},
+		{"non-integer type", "whatever", "String", true},
+		{"non-string value", 42, "UInt64", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, IsValueSafeForFloat64(tt.value, tt.fieldType))
+		})
+	}
+}
+
+func TestNewDataFieldByTypeOptimized(t *testing.T) {
+	tests := []struct {
+		name      string
+		fieldName string
+		fieldType string
+		stringPre bool
+		want      data.FieldType
+	}{
+		{"string", "s", "String", true, data.FieldTypeString},
+		{"nullable string", "s", "Nullable(String)", true, data.FieldTypeNullableString},
+		{"lowcardinality string", "s", "LowCardinality(String)", true, data.FieldTypeString},
+		{"uuid", "s", "UUID", true, data.FieldTypeString},
+		{"uint32", "v", "UInt32", true, data.FieldTypeFloat64},
+		{"nullable float64", "v", "Nullable(Float64)", true, data.FieldTypeNullableFloat64},
+		{"uint64 t timestamp", "t", "UInt64", true, data.FieldTypeTime},
+		{"uint64 nullable t", "t", "Nullable(UInt64)", true, data.FieldTypeNullableString},
+		{"uint64 string precision", "v", "UInt64", true, data.FieldTypeString},
+		{"uint64 float mode", "v", "UInt64", false, data.FieldTypeFloat64},
+		{"int64 string precision", "v", "Int64", true, data.FieldTypeString},
+		{"int64 float mode", "v", "Int64", false, data.FieldTypeFloat64},
+		{"decimal", "v", "Decimal(10,2)", true, data.FieldTypeFloat64},
+		{"fixed string", "v", "FixedString(3)", true, data.FieldTypeString},
+		{"enum", "v", "Enum8('a' = 1)", true, data.FieldTypeString},
+		{"datetime", "d", "DateTime", true, data.FieldTypeTime},
+		{"nullable datetime", "d", "Nullable(DateTime)", true, data.FieldTypeNullableTime},
+		{"datetime64", "d", "DateTime64(3)", true, data.FieldTypeTime},
+		{"date", "d", "Date", true, data.FieldTypeTime},
+		{"unknown", "v", "SomethingElse", true, data.FieldTypeString},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewDataFieldByTypeOptimized(tt.fieldName, tt.fieldType, tt.stringPre)
+			require.Equal(t, tt.want, got.Type())
+			require.Equal(t, tt.fieldName, got.Name)
+		})
+	}
+}
+
+func TestNewDataFieldByType(t *testing.T) {
+	require.Equal(t, data.FieldTypeString, NewDataFieldByType("v", "UInt64").Type())
+}
+
+func TestParseValueOptimized(t *testing.T) {
+	tz := time.UTC
+	ts := time.Unix(0, 1609459200000*int64(time.Millisecond))
+	tests := []struct {
+		name      string
+		fieldName string
+		fieldType string
+		value     interface{}
+		stringPre bool
+		want      Value
+	}{
+		{"string", "s", "String", "abc", true, "abc"},
+		{"nullable string", "s", "Nullable(String)", "abc", true, ptr("abc")},
+		{"nullable string nil", "s", "Nullable(String)", nil, true, nil},
+		{"lowcardinality string", "s", "LowCardinality(String)", "abc", true, "abc"},
+		{"uuid", "s", "UUID", "id", true, "id"},
+		{"map", "m", "Map(String,String)", map[string]interface{}{"k": "v"}, true, `{"k":"v"}`},
+		{"map non-map", "m", "Map(String,String)", "x", true, ""},
+		{"float64 number", "v", "Float64", json.Number("1.5"), true, 1.5},
+		{"float64 raw", "v", "Float64", 2.5, true, 2.5},
+		{"nullable uint8", "v", "Nullable(UInt8)", json.Number("7"), true, ptr(7.0)},
+		{"uint64 t timestamp", "t", "UInt64", json.Number("1609459200000"), true, ts},
+		{"int64 t timestamp", "t", "Int64", json.Number("1609459200000"), true, ts},
+		{"uint64 as string", "v", "UInt64", json.Number("18446744073709551615"), true, "18446744073709551615"},
+		{"uint64 as float", "v", "UInt64", json.Number("42"), false, 42.0},
+		{"int64 as string", "v", "Int64", json.Number("-9223372036854775808"), true, "-9223372036854775808"},
+		{"int64 as float", "v", "Int64", json.Number("-5"), false, -5.0},
+		{"nullable uint64 nil", "v", "Nullable(UInt64)", nil, true, nil},
+		{"decimal", "v", "Decimal(10,2)", json.Number("1.23"), true, 1.23},
+		{"fixed string", "v", "FixedString(3)", "abc", true, "abc"},
+		{"enum", "v", "Enum8('a' = 1)", "a", true, "a"},
+		{"datetime64 3", "d", "DateTime64(3)", "2024-01-15 10:00:00.123", true, time.Date(2024, 1, 15, 10, 0, 0, 123000000, tz)},
+		{"datetime64 6", "d", "DateTime64(6)", "2024-01-15 10:00:00.123456", true, time.Date(2024, 1, 15, 10, 0, 0, 123456000, tz)},
+		{"datetime", "d", "DateTime", "2024-01-15 10:00:00", true, time.Date(2024, 1, 15, 10, 0, 0, 0, tz)},
+		{"date", "d", "Date", "2024-01-15", true, time.Date(2024, 1, 15, 0, 0, 0, 0, tz)},
+		{"unknown compound json fallback", "v", "Array(String)", []interface{}{"a"}, true, `["a"]`},
+		{"unknown unmarshalable", "v", "SomethingElse", make(chan int), true, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, ParseValueOptimized(tt.fieldName, tt.fieldType, tz, tt.value, false, tt.stringPre))
+		})
+	}
+}
+
+func TestParseValueDefaultsToStringPrecision(t *testing.T) {
+	require.Equal(t, "1", ParseValue("v", "UInt64", time.UTC, json.Number("1"), false))
+}
+
+func TestParseUInt64Value(t *testing.T) {
+	require.Equal(t, uint64(18446744073709551615), parseUInt64Value(json.Number("18446744073709551615"), false))
+	require.Equal(t, ptr(uint64(7)), parseUInt64Value("7", true))
+	require.Equal(t, uint64(0), parseUInt64Value("abc", false))
+	require.Nil(t, parseUInt64Value("abc", true))
+	require.Nil(t, parseUInt64Value(nil, true))
+	require.Equal(t, uint64(0), parseUInt64Value(nil, false))
+}
+
+func TestParseInt64Value(t *testing.T) {
+	require.Equal(t, int64(-9223372036854775808), parseInt64Value(json.Number("-9223372036854775808"), false))
+	require.Equal(t, ptr(int64(-7)), parseInt64Value("-7", true))
+	require.Equal(t, int64(0), parseInt64Value("abc", false))
+	require.Nil(t, parseInt64Value("abc", true))
+	require.Nil(t, parseInt64Value(nil, true))
+	require.Equal(t, int64(0), parseInt64Value(nil, false))
+}
+
+func TestParseIntegersAsStringValue(t *testing.T) {
+	require.Equal(t, "0", parseUInt64AsStringValue(nil, false))
+	require.Nil(t, parseUInt64AsStringValue(nil, true))
+	require.Equal(t, "18446744073709551615", parseUInt64AsStringValue(json.Number("18446744073709551615"), false))
+	require.Equal(t, ptr("42"), parseUInt64AsStringValue(42, true))
+	require.Equal(t, "0", parseInt64AsStringValue(nil, false))
+	require.Nil(t, parseInt64AsStringValue(nil, true))
+	require.Equal(t, "-1", parseInt64AsStringValue(json.Number("-1"), false))
+	require.Equal(t, ptr("-42"), parseInt64AsStringValue(-42, true))
+}
+
+func TestParseIntegersAsFloat64Value(t *testing.T) {
+	require.Equal(t, 0.0, parseUInt64AsFloat64Value(nil, false))
+	require.Nil(t, parseUInt64AsFloat64Value(nil, true))
+	require.Equal(t, float64(18446744073709551615), parseUInt64AsFloat64Value(json.Number("18446744073709551615"), false))
+	require.Equal(t, 0.0, parseUInt64AsFloat64Value("abc", false))
+	require.Nil(t, parseUInt64AsFloat64Value("abc", true))
+	require.Equal(t, ptr(42.0), parseUInt64AsFloat64Value(42, true))
+	require.Equal(t, 0.0, parseInt64AsFloat64Value(nil, false))
+	require.Nil(t, parseInt64AsFloat64Value(nil, true))
+	require.Equal(t, -42.0, parseInt64AsFloat64Value(json.Number("-42"), false))
+	require.Equal(t, 0.0, parseInt64AsFloat64Value("abc", false))
+	require.Nil(t, parseInt64AsFloat64Value("abc", true))
+	require.Equal(t, ptr(-1.0), parseInt64AsFloat64Value("-1", true))
+}
+
+func TestParseTimestampValue(t *testing.T) {
+	ts := time.Unix(0, 1609459200000*int64(time.Millisecond))
+	require.Equal(t, ts, parseTimestampValue(json.Number("1609459200000"), false))
+	require.Equal(t, &ts, parseTimestampValue("1609459200000", true))
+	require.Equal(t, time.Unix(0, 0), parseTimestampValue("abc", false))
+	require.Nil(t, parseTimestampValue(nil, true))
+}
+
+func TestParseDateTimeValue(t *testing.T) {
+	want := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	require.Equal(t, want, parseDateTimeValue("2024-01-15 10:00:00", dateTimeLayout, time.UTC, false))
+	require.Equal(t, &want, parseDateTimeValue("2024-01-15 10:00:00", dateTimeLayout, time.UTC, true))
+	require.Equal(t, time.Unix(0, 0), parseDateTimeValue("garbage", dateTimeLayout, time.UTC, false))
+	require.Nil(t, parseDateTimeValue(nil, dateTimeLayout, time.UTC, true))
+}
+
+func TestParseFloatValue(t *testing.T) {
+	require.Equal(t, 1.5, parseFloatValue(json.Number("1.5"), false))
+	require.Equal(t, ptr(2.5), parseFloatValue(2.5, true))
+	require.Equal(t, 0.0, parseFloatValue(json.Number("abc"), false))
+	require.Nil(t, parseFloatValue(json.Number("abc"), true))
+	require.Nil(t, parseFloatValue(nil, true))
+	require.Equal(t, 0.0, parseFloatValue(nil, false))
+}
+
+func TestParseStringValue(t *testing.T) {
+	require.Equal(t, "x", parseStringValue("x", false))
+	require.Equal(t, ptr("x"), parseStringValue("x", true))
+	require.Nil(t, parseStringValue(nil, true))
+	require.Equal(t, "", parseStringValue(nil, false))
+}
+
+func TestParseMapValue(t *testing.T) {
+	require.Equal(t, `{"a":1}`, parseMapValue(map[string]interface{}{"a": 1}, false))
+	require.Nil(t, parseMapValue(map[string]interface{}{"c": make(chan int)}, false))
+	require.Nil(t, parseMapValue("not a map", true))
+	require.Equal(t, "", parseMapValue("not a map", false))
+}

--- a/pkg/query_test.go
+++ b/pkg/query_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyTimeRangeToQueryNumericDateAndTimeValues(t *testing.T) {
+	from := time.Unix(1640995200, 0).UTC()
+	to := time.Unix(1641081600, 0).UTC()
+	testCases := []struct {
+		dateTimeType string
+		from         string
+		to           string
+	}{
+		{"DATE", "toDate(1640995200)", "toDate(1641081600)"},
+		{"DATE32", "toDate32(1640995200)", "toDate32(1641081600)"},
+		{"DATETIME", "toDateTime(1640995200)", "toDateTime(1641081600)"},
+		{"DATETIME64", "toDateTime64(1640995200.000,3)", "toDateTime64(1641081600.000,3)"},
+		{"TIMESTAMP", "1640995200", "1641081600"},
+		{"TIMESTAMP64_3", "1640995200000", "1641081600000"},
+		{"TIMESTAMP64_6", "1640995200000000", "1641081600000000"},
+		{"TIMESTAMP64_9", "1640995200000000000", "1641081600000000000"},
+		{"FLOAT", "1640995200.000", "1641081600.000"},
+		// unknown type keeps the column comparison but drops the compared value
+		{"", "", ""},
+	}
+	for _, tc := range testCases {
+		t.Run("type "+tc.dateTimeType, func(t *testing.T) {
+			q := Query{
+				RawQuery:     "SELECT * FROM tbl WHERE d >= yesterday() AND d <= today() AND ts >= now() AND ts <= now()",
+				DateCol:      "d",
+				DateTimeCol:  "ts",
+				DateTimeType: tc.dateTimeType,
+				From:         from,
+				To:           to,
+			}
+			expected := fmt.Sprintf(
+				"SELECT * FROM tbl WHERE d >= toDate(1640995200) AND d <= toDate(1641081600) AND ts >= %s AND ts <= %s FORMAT JSON",
+				tc.from, tc.to,
+			)
+			require.Equal(t, expected, q.ApplyTimeRangeToQuery())
+		})
+	}
+}
+
+func TestApplyTimeRangeToQueryTimeValueReplacement(t *testing.T) {
+	from := time.Unix(1640995200, 0).UTC()
+	to := time.Unix(1641081600, 0).UTC()
+	testCases := []struct {
+		name     string
+		rawQuery string
+		expected string
+	}{
+		{
+			"trims and appends FORMAT JSON",
+			"SELECT 1;\r\n\t ",
+			"SELECT 1 FORMAT JSON",
+		},
+		{
+			"toDateTime range values replaced",
+			"SELECT c FROM tbl WHERE ts >= toDateTime(1111111111) AND ts <= toDateTime(2222222222)",
+			"SELECT c FROM tbl WHERE ts >= toDateTime(1640995200) AND ts <= toDateTime(1641081600) FORMAT JSON",
+		},
+		{
+			"toDate BETWEEN values replaced",
+			"SELECT c FROM tbl WHERE d BETWEEN toDate(1111111111) AND toDate(2222222222)",
+			"SELECT c FROM tbl WHERE d BETWEEN toDate(1640995200) AND toDate(1641081600) FORMAT JSON",
+		},
+		{
+			"toDateTime64 millisecond values replaced",
+			"SELECT c FROM tbl WHERE ts >= toDateTime64(1111111111111/1000, 3) AND ts <= toDateTime64(2222222222222/1000, 3)",
+			"SELECT c FROM tbl WHERE ts >= toDateTime64(1640995200000/1000, 3) AND ts <= toDateTime64(1641081600000/1000, 3) FORMAT JSON",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			q := Query{RawQuery: tc.rawQuery, From: from, To: to}
+			require.Equal(t, tc.expected, q.ApplyTimeRangeToQuery())
+		})
+	}
+}

--- a/pkg/requests/request_response_test.go
+++ b/pkg/requests/request_response_test.go
@@ -1,0 +1,48 @@
+package requests
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/require"
+)
+
+type captureSender struct{ resps []*backend.CallResourceResponse }
+
+func (s *captureSender) Send(r *backend.CallResourceResponse) error {
+	s.resps = append(s.resps, r)
+	return nil
+}
+
+func TestUnmarshalRequest(t *testing.T) {
+	type payload struct {
+		Query string `json:"query"`
+	}
+
+	t.Run("valid body", func(t *testing.T) {
+		sender := &captureSender{}
+		req, ok := UnmarshalRequest[payload](&backend.CallResourceRequest{Body: []byte(`{"query":"SELECT 1"}`)}, sender)
+		require.True(t, ok)
+		require.Equal(t, "SELECT 1", req.Query)
+		require.Empty(t, sender.resps)
+	})
+
+	t.Run("invalid body", func(t *testing.T) {
+		sender := &captureSender{}
+		req, ok := UnmarshalRequest[payload](&backend.CallResourceRequest{Body: []byte(`{bad`)}, sender)
+		require.False(t, ok)
+		require.Nil(t, req)
+		require.Len(t, sender.resps, 1)
+		require.Equal(t, http.StatusBadRequest, sender.resps[0].Status)
+	})
+}
+
+func TestSendSuccessResponse(t *testing.T) {
+	sender := &captureSender{}
+	require.NoError(t, SendSuccessResponse(sender, map[string]string{"sql": "SELECT 1"}))
+	require.Len(t, sender.resps, 1)
+	require.Equal(t, http.StatusOK, sender.resps[0].Status)
+	require.Equal(t, []string{"application/json"}, sender.resps[0].Headers["Content-Type"])
+	require.JSONEq(t, `{"sql":"SELECT 1"}`, string(sender.resps[0].Body))
+}

--- a/pkg/resource_handlers_test.go
+++ b/pkg/resource_handlers_test.go
@@ -1,0 +1,516 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/altinity/clickhouse-grafana/pkg/eval"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/require"
+)
+
+type captureSender struct{ resp *backend.CallResourceResponse }
+
+func (s *captureSender) Send(r *backend.CallResourceResponse) error { s.resp = r; return nil }
+
+func callResource(t *testing.T, path string, body interface{}) *backend.CallResourceResponse {
+	t.Helper()
+	var raw []byte
+	if s, ok := body.(string); ok {
+		raw = []byte(s)
+	} else {
+		var err error
+		raw, err = json.Marshal(body)
+		require.NoError(t, err)
+	}
+	sender := &captureSender{}
+	ds := &ClickHouseDatasource{}
+	require.NoError(t, ds.CallResource(context.Background(), &backend.CallResourceRequest{Path: path, Body: raw}, sender))
+	require.NotNil(t, sender.resp)
+	return sender.resp
+}
+
+func decodeBody(t *testing.T, resp *backend.CallResourceResponse) map[string]interface{} {
+	t.Helper()
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(resp.Body, &m))
+	return m
+}
+
+func mustAST(t *testing.T, sql string) *eval.EvalAST {
+	t.Helper()
+	scanner := eval.NewScanner(sql)
+	ast, err := scanner.ToAST()
+	require.NoError(t, err)
+	return ast
+}
+
+var testTimeRange = map[string]string{"from": "2024-01-01T00:00:00Z", "to": "2024-01-02T00:00:00Z"}
+
+func TestParseTargets(t *testing.T) {
+	tests := []struct {
+		name         string
+		from         string
+		wantDatabase string
+		wantTable    string
+	}{
+		{"empty", "", "", ""},
+		{"table only uses default db", "tbl", "defaultDB", "tbl"},
+		{"db and table", "db.tbl", "db", "tbl"},
+		{"too many parts", "a.b.c", "", ""},
+		{"$table replaced", "$table", "defaultDB", "defaultTable"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, table := parseTargets(tt.from, "defaultDB", "defaultTable")
+			require.Equal(t, tt.wantDatabase, db)
+			require.Equal(t, tt.wantTable, table)
+		})
+	}
+}
+
+func TestFindGroupByProperties(t *testing.T) {
+	tests := []struct {
+		name string
+		ast  *eval.EvalAST
+		want []interface{}
+	}{
+		{"top level", mustAST(t, "SELECT x FROM default.test GROUP BY host, ip"), []interface{}{"host", "ip"}},
+		{"subquery", mustAST(t, "SELECT x FROM (SELECT x FROM default.test GROUP BY host)"), []interface{}{"host"}},
+		{"none", mustAST(t, "SELECT x FROM default.test"), []interface{}{}},
+		{"slice value", &eval.EvalAST{Obj: map[string]interface{}{"group by": []interface{}{"a"}}}, []interface{}{"a"}},
+		{"scalar value", &eval.EvalAST{Obj: map[string]interface{}{"group by": "a"}}, []interface{}{"a"}},
+		{"nested in non-from key", &eval.EvalAST{Obj: map[string]interface{}{
+			"foo": &eval.EvalAST{Obj: map[string]interface{}{"group by": "b"}},
+		}}, []interface{}{"b"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, findGroupByProperties(tt.ast))
+		})
+	}
+}
+
+func TestFindUnreplacedMacros(t *testing.T) {
+	got := findUnreplacedMacros("SELECT $timeSeries FROM $table WHERE $timeFilter AND $adhoc")
+	require.Len(t, got, 4)
+	require.Empty(t, findUnreplacedMacros("SELECT 1 FROM t"))
+}
+
+func TestCreateUniversalErrorResponse(t *testing.T) {
+	tests := []struct {
+		name        string
+		ctx         ErrorContext
+		wantMsgPart string
+		wantSQLKey  bool
+	}{
+		{"time range", ErrorContext{ErrorType: ErrorTypeTimeRange, OriginalError: fmt.Errorf("bad")}, "Time range processing failed", false},
+		{"macro expansion with unreplaced", ErrorContext{ErrorType: ErrorTypeMacroExpansion, OriginalSQL: "SELECT $timeFilter", OriginalError: fmt.Errorf("bad")}, "Found unreplaced macros", false},
+		{"macro expansion clean", ErrorContext{ErrorType: ErrorTypeMacroExpansion, OriginalSQL: "SELECT 1", OriginalError: fmt.Errorf("bad")}, "check your macro syntax", false},
+		{"query parsing with adhoc", ErrorContext{ErrorType: ErrorTypeQueryParsing, OriginalSQL: "SELECT * WHERE $adhoc", HasAdhocMacro: true, OriginalError: fmt.Errorf("bad")}, "replaced with '1' as a fallback", true},
+		{"query parsing with unreplaced", ErrorContext{ErrorType: ErrorTypeQueryParsing, OriginalSQL: "SELECT $timeSeries", OriginalError: fmt.Errorf("bad")}, "Found unreplaced macros", false},
+		{"query parsing clean", ErrorContext{ErrorType: ErrorTypeQueryParsing, OriginalSQL: "SELECT 1", OriginalError: fmt.Errorf("bad")}, "check your SQL syntax", false},
+		{"from clause with adhoc", ErrorContext{ErrorType: ErrorTypeFromClause, OriginalSQL: "SELECT * WHERE $adhoc", HasAdhocMacro: true, OriginalError: fmt.Errorf("bad")}, "Cannot determine target table", true},
+		{"from clause plain", ErrorContext{ErrorType: ErrorTypeFromClause, OriginalError: fmt.Errorf("bad")}, "FROM clause parsing failed", false},
+		{"adhoc filters", ErrorContext{ErrorType: ErrorTypeAdhocFilters, OriginalError: fmt.Errorf("bad")}, "Adhoc filter processing failed", false},
+		{"ast extraction", ErrorContext{ErrorType: ErrorTypeAstExtraction, OriginalError: fmt.Errorf("bad")}, "AST property extraction failed", false},
+		{"general with unreplaced", ErrorContext{ErrorType: ErrorTypeGeneral, OriginalSQL: "SELECT $from", OriginalError: fmt.Errorf("boom")}, "unreplaced macros", false},
+		{"general clean", ErrorContext{ErrorType: ErrorTypeGeneral, OriginalSQL: "SELECT 1", OriginalError: fmt.Errorf("boom")}, "boom", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, processedSQL := createUniversalErrorResponse(tt.ctx)
+			require.Contains(t, resp["error"].(string), tt.wantMsgPart)
+			require.NotContains(t, processedSQL, "$adhoc")
+			_, hasSQL := resp["sql"]
+			require.Equal(t, tt.wantSQLKey, hasSQL)
+			if hasSQL {
+				require.NotContains(t, resp["sql"].(string), "$adhoc")
+			}
+		})
+	}
+}
+
+func TestCallResourceUnknownPath(t *testing.T) {
+	resp := callResource(t, "nope", `{}`)
+	require.Equal(t, http.StatusNotFound, resp.Status)
+	require.Contains(t, string(resp.Body), "Resource not found")
+}
+
+func TestCallResourceMalformedBody(t *testing.T) {
+	for _, path := range []string{"createQuery", "applyAdhocFilters", "getAstProperty", "replaceTimeFilters", "processQueryBatch", "createQueryWithAdhoc", "getMultipleAstProperties"} {
+		t.Run(path, func(t *testing.T) {
+			resp := callResource(t, path, `{not json`)
+			require.Equal(t, http.StatusBadRequest, resp.Status)
+			require.Contains(t, string(resp.Body), "Invalid request")
+		})
+	}
+}
+
+func TestHandleCreateQuery(t *testing.T) {
+	base := map[string]interface{}{
+		"query":               "SELECT $timeSeries as t, count() FROM default.test WHERE $timeFilter GROUP BY t",
+		"dateTimeColDataType": "event_time",
+		"dateTimeType":        "DATETIME",
+		"interval":            "30s",
+		"database":            "default",
+		"table":               "test",
+		"timeRange":           testTimeRange,
+	}
+
+	t.Run("happy path", func(t *testing.T) {
+		resp := callResource(t, "createQuery", base)
+		require.Equal(t, http.StatusOK, resp.Status)
+		body := decodeBody(t, resp)
+		require.NotContains(t, body["sql"], "$timeSeries")
+		require.NotContains(t, body["sql"], "$timeFilter")
+		require.Contains(t, body["sql"], "FROM default.test")
+		require.Equal(t, []interface{}{"t"}, body["keys"])
+	})
+
+	t.Run("invalid time range", func(t *testing.T) {
+		req := map[string]interface{}{"query": "SELECT 1", "timeRange": map[string]string{"from": "bad", "to": "bad"}}
+		resp := callResource(t, "createQuery", req)
+		require.Equal(t, http.StatusBadRequest, resp.Status)
+		require.Contains(t, decodeBody(t, resp)["error"], "Time range processing failed")
+	})
+
+	t.Run("macro failure", func(t *testing.T) {
+		req := map[string]interface{}{"query": "SELECT 1 FROM t", "interval": "xs", "timeRange": testTimeRange}
+		resp := callResource(t, "createQuery", req)
+		require.Equal(t, http.StatusInternalServerError, resp.Status)
+		require.Contains(t, decodeBody(t, resp)["error"], "Macro expansion failed")
+	})
+}
+
+func TestHandleApplyAdhocFilters(t *testing.T) {
+	filters := []map[string]interface{}{{"key": "b", "operator": "=", "value": "2"}}
+	target := map[string]string{"database": "default", "table": "test"}
+
+	tests := []struct {
+		name       string
+		body       map[string]interface{}
+		wantStatus int
+		wantQuery  []string
+		wantErr    string
+	}{
+		{
+			"inject into existing WHERE",
+			map[string]interface{}{"query": "SELECT x FROM default.test WHERE a = 1", "adhocFilters": filters, "target": target},
+			http.StatusOK, []string{"WHERE", "a = 1", "AND", "(b = 2)"}, "",
+		},
+		{
+			"inject creates WHERE",
+			map[string]interface{}{"query": "SELECT x FROM default.test", "adhocFilters": filters, "target": target},
+			http.StatusOK, []string{"WHERE", "b = 2"}, "",
+		},
+		{
+			"string value quoted",
+			map[string]interface{}{"query": "SELECT x FROM default.test", "adhocFilters": []map[string]interface{}{{"key": "b", "operator": "=", "value": "web"}}, "target": target},
+			http.StatusOK, []string{"b = 'web'"}, "",
+		},
+		{
+			"adhoc macro replaced with conditions",
+			map[string]interface{}{"query": "SELECT x FROM default.test WHERE $adhoc", "adhocFilters": filters, "target": target},
+			http.StatusOK, []string{"WHERE (b = 2)"}, "",
+		},
+		{
+			"adhoc macro with no filters becomes 1",
+			map[string]interface{}{"query": "SELECT x FROM default.test WHERE $adhoc", "target": target},
+			http.StatusOK, []string{"WHERE 1"}, "",
+		},
+		{
+			"subquery FROM",
+			map[string]interface{}{"query": "SELECT x FROM (SELECT y FROM default.test)", "adhocFilters": filters, "target": target},
+			http.StatusOK, []string{"WHERE b = 2"}, "",
+		},
+		{
+			"parse error",
+			map[string]interface{}{"query": "SELECT x FROM tbl INNER JOIN", "adhocFilters": filters, "target": target},
+			http.StatusInternalServerError, nil, "Query parsing failed",
+		},
+		{
+			"unparseable FROM clause",
+			map[string]interface{}{"query": "SELECT x FROM a.b.c", "adhocFilters": filters, "target": target},
+			http.StatusInternalServerError, nil, "FROM clause parsing failed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := callResource(t, "applyAdhocFilters", tt.body)
+			require.Equal(t, tt.wantStatus, resp.Status)
+			body := decodeBody(t, resp)
+			if tt.wantErr != "" {
+				require.Contains(t, body["error"], tt.wantErr)
+				return
+			}
+			for _, part := range tt.wantQuery {
+				require.Contains(t, body["query"], part)
+			}
+			require.NotContains(t, body["query"], "$adhoc")
+		})
+	}
+}
+
+func TestHandleReplaceTimeFilters(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		body := map[string]interface{}{
+			"query":        "SELECT x FROM t WHERE d >= toDateTime($from) AND d <= toDateTime($to)",
+			"dateTimeType": "DATETIME",
+			"timeRange":    testTimeRange,
+		}
+		resp := callResource(t, "replaceTimeFilters", body)
+		require.Equal(t, http.StatusOK, resp.Status)
+		sql := decodeBody(t, resp)["sql"].(string)
+		require.NotContains(t, sql, "$from")
+		require.NotContains(t, sql, "$to")
+		require.Contains(t, sql, "1704067200")
+	})
+
+	for _, tt := range []struct{ name, from, to, wantErr string }{
+		{"bad from", "bad", "2024-01-02T00:00:00Z", "Invalid from time"},
+		{"bad to", "2024-01-01T00:00:00Z", "bad", "Invalid to time"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			body := map[string]interface{}{"query": "SELECT 1", "timeRange": map[string]string{"from": tt.from, "to": tt.to}}
+			resp := callResource(t, "replaceTimeFilters", body)
+			require.Equal(t, http.StatusBadRequest, resp.Status)
+			require.Equal(t, tt.wantErr, decodeBody(t, resp)["error"])
+		})
+	}
+}
+
+func TestHandleGetAstProperty(t *testing.T) {
+	query := "SELECT x, y FROM default.test WHERE a = 1 AND b = 2 GROUP BY host LIMIT 10"
+	tests := []struct {
+		name       string
+		query      string
+		property   string
+		wantStatus int
+		want       []interface{}
+	}{
+		{"group by recursive", "SELECT x FROM (SELECT x FROM default.test GROUP BY host)", "group by", http.StatusOK, []interface{}{"host"}},
+		{"select", query, "select", http.StatusOK, []interface{}{"x", "y"}},
+		{"where", query, "where", http.StatusOK, []interface{}{"a = 1", "AND b = 2"}},
+		{"limit", query, "limit", http.StatusOK, []interface{}{"10"}},
+		{"missing property", query, "having", http.StatusOK, nil},
+		{"parse error", "SELECT x FROM tbl INNER JOIN", "select", http.StatusInternalServerError, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := callResource(t, "getAstProperty", map[string]string{"query": tt.query, "propertyName": tt.property})
+			require.Equal(t, tt.wantStatus, resp.Status)
+			body := decodeBody(t, resp)
+			if tt.wantStatus != http.StatusOK {
+				require.Contains(t, body["error"], "AST property extraction failed")
+				return
+			}
+			if tt.want == nil {
+				require.Empty(t, body["properties"])
+			} else {
+				require.Equal(t, tt.want, body["properties"])
+			}
+		})
+	}
+}
+
+func TestHandleGetMultipleAstProperties(t *testing.T) {
+	t.Run("mixed properties", func(t *testing.T) {
+		body := map[string]interface{}{
+			"query":      "SELECT x FROM default.test WHERE a = 1 GROUP BY host",
+			"properties": []string{"group by", "where", "select", "having"},
+		}
+		resp := callResource(t, "getMultipleAstProperties", body)
+		require.Equal(t, http.StatusOK, resp.Status)
+		props := decodeBody(t, resp)["properties"].(map[string]interface{})
+		require.Equal(t, []interface{}{"host"}, props["group by"])
+		require.Equal(t, []interface{}{"a = 1"}, props["where"])
+		require.Equal(t, []interface{}{"x"}, props["select"])
+		require.Empty(t, props["having"])
+	})
+
+	t.Run("parse error", func(t *testing.T) {
+		body := map[string]interface{}{"query": "SELECT x FROM tbl INNER JOIN", "properties": []string{"select"}}
+		resp := callResource(t, "getMultipleAstProperties", body)
+		require.Equal(t, http.StatusInternalServerError, resp.Status)
+		require.Contains(t, decodeBody(t, resp)["error"], "Failed to parse query")
+	})
+}
+
+func TestHandleProcessQueryBatch(t *testing.T) {
+	filters := []map[string]interface{}{{"key": "b", "operator": "=", "value": "2"}}
+	target := map[string]string{"database": "default", "table": "test"}
+	base := func() map[string]interface{} {
+		return map[string]interface{}{
+			"query":               "SELECT $timeSeries as t, count() FROM default.test WHERE $timeFilter GROUP BY t LIMIT 10",
+			"dateTimeColDataType": "event_time",
+			"dateTimeType":        "DATETIME",
+			"interval":            "30s",
+			"database":            "default",
+			"table":               "test",
+			"timeRange":           testTimeRange,
+			"target":              target,
+		}
+	}
+
+	t.Run("happy path with property extraction", func(t *testing.T) {
+		req := base()
+		req["extractProperties"] = []string{"group by", "select", "where", "limit", "having"}
+		resp := callResource(t, "processQueryBatch", req)
+		require.Equal(t, http.StatusOK, resp.Status)
+		body := decodeBody(t, resp)
+		require.NotContains(t, body["sql"], "$timeFilter")
+		require.Equal(t, []interface{}{"t"}, body["keys"])
+		props := body["properties"].(map[string]interface{})
+		require.Equal(t, []interface{}{"t"}, props["group by"])
+		require.Equal(t, []interface{}{"10"}, props["limit"])
+		require.NotEmpty(t, props["select"])
+		require.NotEmpty(t, props["where"])
+		require.Empty(t, props["having"])
+	})
+
+	t.Run("adhoc filters injected", func(t *testing.T) {
+		req := base()
+		req["adhocFilters"] = filters
+		resp := callResource(t, "processQueryBatch", req)
+		require.Equal(t, http.StatusOK, resp.Status)
+		require.Contains(t, decodeBody(t, resp)["sql"], "(b = 2)")
+	})
+
+	t.Run("adhoc macro replaced", func(t *testing.T) {
+		req := base()
+		req["query"] = "SELECT $timeSeries as t, count() FROM default.test WHERE $timeFilter AND $adhoc GROUP BY t"
+		req["adhocFilters"] = filters
+		resp := callResource(t, "processQueryBatch", req)
+		require.Equal(t, http.StatusOK, resp.Status)
+		sql := decodeBody(t, resp)["sql"].(string)
+		require.Contains(t, sql, "(b = 2)")
+		require.NotContains(t, sql, "$adhoc")
+	})
+
+	t.Run("adhoc macro with non-matching filters becomes 1", func(t *testing.T) {
+		req := base()
+		req["query"] = "SELECT $timeSeries as t, count() FROM default.test WHERE $timeFilter AND $adhoc GROUP BY t"
+		req["adhocFilters"] = []map[string]interface{}{{"key": "other.tbl.col", "operator": "=", "value": "2"}}
+		resp := callResource(t, "processQueryBatch", req)
+		require.Equal(t, http.StatusOK, resp.Status)
+		sql := decodeBody(t, resp)["sql"].(string)
+		require.Contains(t, sql, "AND 1")
+		require.NotContains(t, sql, "$adhoc")
+	})
+
+	t.Run("unparseable FROM clause", func(t *testing.T) {
+		req := base()
+		req["query"] = "SELECT x FROM a.b.c WHERE $timeFilter"
+		req["adhocFilters"] = filters
+		resp := callResource(t, "processQueryBatch", req)
+		require.Equal(t, http.StatusInternalServerError, resp.Status)
+		require.Contains(t, decodeBody(t, resp)["error"], "FROM expression can't be parsed")
+	})
+
+	t.Run("macro failure", func(t *testing.T) {
+		req := base()
+		req["interval"] = "xs"
+		resp := callResource(t, "processQueryBatch", req)
+		require.Equal(t, http.StatusInternalServerError, resp.Status)
+		require.Contains(t, decodeBody(t, resp)["error"], "Failed to apply macros")
+	})
+
+	for _, tt := range []struct{ name, from, to, wantErr string }{
+		{"bad from", "bad", "2024-01-02T00:00:00Z", "Invalid `$from` time"},
+		{"bad to", "2024-01-01T00:00:00Z", "bad", "Invalid `$to` time"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := base()
+			req["timeRange"] = map[string]string{"from": tt.from, "to": tt.to}
+			resp := callResource(t, "processQueryBatch", req)
+			require.Equal(t, http.StatusBadRequest, resp.Status)
+			require.Equal(t, tt.wantErr, decodeBody(t, resp)["error"])
+		})
+	}
+}
+
+func TestHandleCreateQueryWithAdhoc(t *testing.T) {
+	filters := []map[string]interface{}{{"key": "b", "operator": "=", "value": "2"}}
+	target := map[string]string{"database": "default", "table": "test"}
+	base := func(query string) map[string]interface{} {
+		return map[string]interface{}{
+			"query":               query,
+			"dateTimeColDataType": "event_time",
+			"dateTimeType":        "DATETIME",
+			"interval":            "30s",
+			"database":            "default",
+			"table":               "test",
+			"timeRange":           testTimeRange,
+			"target":              target,
+		}
+	}
+	plain := "SELECT $timeSeries as t, count() FROM default.test WHERE $timeFilter GROUP BY t"
+	withAdhoc := "SELECT $timeSeries as t, count() FROM default.test WHERE $timeFilter AND $adhoc GROUP BY t"
+
+	tests := []struct {
+		name       string
+		body       map[string]interface{}
+		mutate     func(map[string]interface{})
+		wantStatus int
+		wantSQL    []string
+		wantErr    string
+	}{
+		{"no filters no adhoc", base(plain), nil, http.StatusOK, []string{"FROM default.test"}, ""},
+		{"filters injected", base(plain), func(m map[string]interface{}) { m["adhocFilters"] = filters }, http.StatusOK, []string{"(b = 2)"}, ""},
+		{"adhoc replaced with conditions", base(withAdhoc), func(m map[string]interface{}) { m["adhocFilters"] = filters }, http.StatusOK, []string{"(b = 2)"}, ""},
+		{"adhoc no filters becomes 1", base(withAdhoc), nil, http.StatusOK, []string{"AND 1"}, ""},
+		{
+			"adhoc with non-matching filters becomes 1", base(withAdhoc),
+			func(m map[string]interface{}) {
+				m["adhocFilters"] = []map[string]interface{}{{"key": "other.tbl.col", "operator": "=", "value": "2"}}
+			},
+			http.StatusOK, []string{"AND 1"}, "",
+		},
+		{
+			"unparseable FROM clause", base("SELECT x FROM a.b.c WHERE $timeFilter"),
+			func(m map[string]interface{}) { m["adhocFilters"] = filters },
+			http.StatusInternalServerError, nil, "FROM clause parsing failed",
+		},
+		{
+			"macro failure", base(plain),
+			func(m map[string]interface{}) { m["interval"] = "xs" },
+			http.StatusInternalServerError, nil, "Macro expansion failed",
+		},
+		{
+			"bad from", base(plain),
+			func(m map[string]interface{}) {
+				m["timeRange"] = map[string]string{"from": "bad", "to": "2024-01-02T00:00:00Z"}
+			},
+			http.StatusBadRequest, nil, "Invalid `$from` time",
+		},
+		{
+			"bad to", base(plain),
+			func(m map[string]interface{}) {
+				m["timeRange"] = map[string]string{"from": "2024-01-01T00:00:00Z", "to": "bad"}
+			},
+			http.StatusBadRequest, nil, "Invalid `$to` time",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.mutate != nil {
+				tt.mutate(tt.body)
+			}
+			resp := callResource(t, "createQueryWithAdhoc", tt.body)
+			require.Equal(t, tt.wantStatus, resp.Status)
+			body := decodeBody(t, resp)
+			if tt.wantErr != "" {
+				require.Contains(t, body["error"], tt.wantErr)
+				return
+			}
+			for _, part := range tt.wantSQL {
+				require.Contains(t, body["sql"], part)
+			}
+			require.NotContains(t, body["sql"], "$adhoc")
+		})
+	}
+}

--- a/pkg/response_test.go
+++ b/pkg/response_test.go
@@ -2,8 +2,12 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/stretchr/testify/require"
 )
 
 // TestToFramesWithTimeStampAndLabels verifies that 3-field queries
@@ -109,4 +113,122 @@ func TestToFramesWithTimeStampNoLabels(t *testing.T) {
 	if frame.Fields[1].Len() != 2 {
 		t.Errorf("expected 2 data points, got %d", frame.Fields[1].Len())
 	}
+}
+
+var fetchUTC = func(ctx context.Context) *time.Location { return time.UTC }
+
+// TestToFramesTable covers the table branch (no timestamp column in Meta)
+// and string precision preservation for UInt64 values above 2^53
+func TestToFramesTable(t *testing.T) {
+	r := &Response{
+		ctx:  context.Background(),
+		Meta: []*FieldMeta{{Name: "name", Type: "String"}, {Name: "big", Type: "UInt64"}},
+		Data: []map[string]interface{}{
+			{"name": "a", "big": json.Number("9007199254740993")},
+			{"name": "b", "big": json.Number("1")},
+		},
+	}
+	frames, err := r.toFrames(&Query{RefId: "A"}, fetchUTC)
+	require.NoError(t, err)
+	require.Len(t, frames, 2)
+	for _, frame := range frames {
+		require.Equal(t, "A", frame.RefID)
+		require.Len(t, frame.Fields, 1)
+		require.Equal(t, data.FieldTypeString, frame.Fields[0].Type())
+		require.Equal(t, 2, frame.Fields[0].Len())
+	}
+}
+
+func TestToFramesWithTimeStampSeriesFromMacros(t *testing.T) {
+	r := &Response{
+		ctx: context.Background(),
+		Meta: []*FieldMeta{
+			{Name: "t", Type: "DateTime"},
+			{Name: "garr", Type: "Array(Tuple(String, Float64))"},
+		},
+		Data: []map[string]interface{}{
+			{"t": "2024-01-15 10:00:00", "garr": []interface{}{
+				[]interface{}{"web", 1.0},
+				[]interface{}{nil, 2.0},
+			}},
+		},
+	}
+	frames, err := r.toFrames(&Query{RefId: "B"}, fetchUTC)
+	require.NoError(t, err)
+	require.Len(t, frames, 2)
+	values := map[string]float64{}
+	for _, frame := range frames {
+		require.Len(t, frame.Fields, 2)
+		values[frame.Fields[1].Name] = frame.Fields[1].At(0).(float64)
+	}
+	// nil label becomes a "null" series
+	require.Equal(t, map[string]float64{"web": 1.0, "null": 2.0}, values)
+}
+
+func TestToFramesWithTimeStampSeriesFromMacrosErrors(t *testing.T) {
+	meta := []*FieldMeta{
+		{Name: "t", Type: "DateTime"},
+		{Name: "garr", Type: "Array(Tuple(String, Float64))"},
+	}
+	testCases := []struct {
+		name        string
+		garr        interface{}
+		expectedErr string
+	}{
+		{"malformed tuple", []interface{}{"bad"}, "unable to parse data section type=string"},
+		{"malformed array", "bad", "unable to parse data section name=garr type=string"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &Response{
+				ctx:  context.Background(),
+				Meta: meta,
+				Data: []map[string]interface{}{{"t": "2024-01-15 10:00:00", "garr": tc.garr}},
+			}
+			_, err := r.toFrames(&Query{RefId: "B"}, fetchUTC)
+			require.ErrorContains(t, err, tc.expectedErr)
+		})
+	}
+}
+
+func TestToFramesTimestampParseError(t *testing.T) {
+	r := &Response{
+		ctx:  context.Background(),
+		Meta: []*FieldMeta{{Name: "t", Type: "Nullable(UInt64)"}, {Name: "v", Type: "Float64"}},
+		Data: []map[string]interface{}{{"t": nil, "v": 1.0}},
+	}
+	_, err := r.toFrames(&Query{RefId: "C"}, fetchUTC)
+	require.ErrorContains(t, err, "Unexpected type from ParseValue of field t")
+}
+
+// TestToFramesUInt64Timestamp covers the "t" UInt64 millisecond timestamp column
+func TestToFramesUInt64Timestamp(t *testing.T) {
+	r := &Response{
+		ctx:  context.Background(),
+		Meta: []*FieldMeta{{Name: "t", Type: "UInt64"}, {Name: "v", Type: "Float64"}},
+		Data: []map[string]interface{}{{"t": json.Number("1705312800000"), "v": 1.5}},
+	}
+	frames, err := r.toFrames(&Query{RefId: "D"}, fetchUTC)
+	require.NoError(t, err)
+	require.Len(t, frames, 1)
+	require.Equal(t, data.FieldTypeTime, frames[0].Fields[0].Type())
+	require.Equal(t, time.UnixMilli(1705312800000).UTC(), frames[0].Fields[0].At(0).(time.Time).UTC())
+	require.Equal(t, 1.5, frames[0].Fields[1].At(0))
+}
+
+func TestAnalyzeColumnPrecisionNeeds(t *testing.T) {
+	r := &Response{
+		Data: []map[string]interface{}{
+			{"a": json.Number("9007199254740993"), "b": json.Number("5"), "skip": json.Number("1")},
+			{"a": json.Number("1"), "b": json.Number("-9007199254740993")},
+		},
+	}
+	needs := r.analyzeColumnPrecisionNeeds(map[string]string{
+		"a": "Nullable(UInt64)",
+		"b": "LowCardinality(Int64)",
+	})
+	require.True(t, needs["a"], "unsafe UInt64 must keep string precision")
+	require.True(t, needs["b"], "unsafe negative Int64 must keep string precision")
+	_, tracked := needs["skip"]
+	require.False(t, tracked, "columns without known integer type are not tracked")
 }

--- a/pkg/streaming_test.go
+++ b/pkg/streaming_test.go
@@ -578,3 +578,322 @@ func TestDeltaKeepsDataOnQueryError(t *testing.T) {
 		require.Empty(t, f.Fields, "frame %d: a failing query must not clear accumulated data", i+1)
 	}
 }
+
+func TestSubscribeAndPublishStream(t *testing.T) {
+	ds := &ClickHouseDatasource{}
+
+	sub, err := ds.SubscribeStream(context.Background(), &backend.SubscribeStreamRequest{Path: "ds/uid/A"})
+	require.NoError(t, err)
+	require.Equal(t, backend.SubscribeStreamStatusOK, sub.Status)
+
+	pub, err := ds.PublishStream(context.Background(), &backend.PublishStreamRequest{})
+	require.NoError(t, err)
+	require.Equal(t, backend.PublishStreamStatusPermissionDenied, pub.Status)
+}
+
+func TestParseIntervalSeconds(t *testing.T) {
+	tests := []struct {
+		in   string
+		want int64
+	}{
+		{"", 0},
+		{"200ms", 0},
+		{"1500ms", 1},
+		{"20s", 20},
+		{"1m", 60},
+		{"1h", 3600},
+		{"1d", 86400},
+		{"5", 5},
+		{"xs", 0},
+	}
+	for _, tt := range tests {
+		t.Run("interval "+tt.in, func(t *testing.T) {
+			require.Equal(t, tt.want, parseIntervalSeconds(tt.in))
+		})
+	}
+}
+
+func TestToFloat64(t *testing.T) {
+	f64 := 1.5
+	f32 := float32(2.5)
+	tests := []struct {
+		name string
+		in   interface{}
+		want float64
+	}{
+		{"float64", 1.5, 1.5},
+		{"float32", float32(2.5), 2.5},
+		{"int64", int64(-3), -3},
+		{"int32", int32(4), 4},
+		{"int", 5, 5},
+		{"uint64", uint64(6), 6},
+		{"uint32", uint32(7), 7},
+		{"*float64", &f64, 1.5},
+		{"*float64 nil", (*float64)(nil), 0},
+		{"*float32", &f32, 2.5},
+		{"*float32 nil", (*float32)(nil), 0},
+		{"string falls back to zero", "8", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, toFloat64(tt.in))
+		})
+	}
+}
+
+func TestFrameFingerprint(t *testing.T) {
+	base := time.Unix(1785000000, 0)
+	a := accumFrame([]time.Time{base, base.Add(time.Minute)}, []float64{1, 2})
+	same := accumFrame([]time.Time{base, base.Add(time.Minute)}, []float64{1, 2})
+	changed := accumFrame([]time.Time{base, base.Add(time.Minute)}, []float64{1, 3})
+
+	require.Equal(t, [16]byte{}, frameFingerprint(accumFrame(nil, nil)))
+	require.Equal(t, frameFingerprint(a), frameFingerprint(same))
+	require.NotEqual(t, frameFingerprint(a), frameFingerprint(changed))
+}
+
+func TestFrameKey(t *testing.T) {
+	base := time.Unix(1785000000, 0)
+
+	named := accumFrame([]time.Time{base}, []float64{1})
+	named.Name = "explicit"
+	require.Equal(t, "explicit", frameKey(named))
+
+	require.Equal(t, "v", frameKey(accumFrame([]time.Time{base}, []float64{1})))
+
+	timeOnly := data.NewFrame("", data.NewField("t", nil, []time.Time{base}))
+	timeOnly.RefID = "R"
+	require.Equal(t, "R", frameKey(timeOnly))
+}
+
+func seriesFrame(name string, times []time.Time, values []float64) *data.Frame {
+	return data.NewFrame("",
+		data.NewField("t", nil, times),
+		data.NewField(name, nil, values),
+	)
+}
+
+func TestMergeFramesToWide(t *testing.T) {
+	base := time.Unix(1785000000, 0)
+	t0, t1, t2 := base, base.Add(time.Minute), base.Add(2*time.Minute)
+
+	t.Run("empty map", func(t *testing.T) {
+		require.Nil(t, mergeFramesToWide(map[string]*data.Frame{}))
+	})
+
+	t.Run("single frame passthrough", func(t *testing.T) {
+		f := seriesFrame("a", []time.Time{t0}, []float64{1})
+		require.Same(t, f, mergeFramesToWide(map[string]*data.Frame{"a": f}))
+	})
+
+	t.Run("overlapping buckets join on a unified sorted time index", func(t *testing.T) {
+		wide := mergeFramesToWide(map[string]*data.Frame{
+			"b": seriesFrame("b", []time.Time{t1, t2}, []float64{20, 21}),
+			"a": seriesFrame("a", []time.Time{t0, t1}, []float64{10, 11}),
+			"c": seriesFrame("c", []time.Time{t0, t2}, []float64{30, 31}),
+		})
+
+		require.Equal(t, 3, wide.Rows())
+		require.Len(t, wide.Fields, 4)
+		require.Equal(t, []string{"t", "a", "b", "c"}, []string{
+			wide.Fields[0].Name, wide.Fields[1].Name, wide.Fields[2].Name, wide.Fields[3].Name,
+		})
+		require.Equal(t, []time.Time{t0, t1, t2}, []time.Time{
+			wide.Fields[0].At(0).(time.Time), wide.Fields[0].At(1).(time.Time), wide.Fields[0].At(2).(time.Time),
+		})
+
+		at := func(fi, r int) *float64 { return wide.Fields[fi].At(r).(*float64) }
+		require.Equal(t, 10.0, *at(1, 0))
+		require.Equal(t, 11.0, *at(1, 1))
+		require.Nil(t, at(1, 2), "series a has no bucket at t2")
+		require.Nil(t, at(2, 0))
+		require.Equal(t, 20.0, *at(2, 1))
+		require.Equal(t, 21.0, *at(2, 2))
+		require.Equal(t, 30.0, *at(3, 0))
+		require.Nil(t, at(3, 1))
+		require.Equal(t, 31.0, *at(3, 2))
+	})
+
+	t.Run("time-only and empty frames contribute no value fields", func(t *testing.T) {
+		wide := mergeFramesToWide(map[string]*data.Frame{
+			"a":     seriesFrame("a", []time.Time{t0}, []float64{1}),
+			"bare":  data.NewFrame("", data.NewField("t", nil, []time.Time{t1})),
+			"empty": data.NewFrame(""),
+		})
+
+		require.Len(t, wide.Fields, 2)
+		// The time-only frame still contributes its timestamp to the index.
+		require.Equal(t, 2, wide.Rows())
+	})
+
+	t.Run("rows keyed by a non-time first field are skipped", func(t *testing.T) {
+		wide := mergeFramesToWide(map[string]*data.Frame{
+			"a": seriesFrame("a", []time.Time{t0}, []float64{1}),
+			"bad": data.NewFrame("",
+				data.NewField("s", nil, []string{"x"}),
+				data.NewField("v", nil, []float64{99}),
+			),
+		})
+
+		require.Equal(t, 1, wide.Rows())
+		for _, f := range wide.Fields[1:] {
+			if f.Name == "v" {
+				require.Nil(t, f.At(0).(*float64), "value keyed by a non-time row must stay null")
+			}
+		}
+	})
+}
+
+func TestDeltaModeRequiresTimeMacro(t *testing.T) {
+	ds := &ClickHouseDatasource{}
+	sink := &capturingSender{}
+	sq := &streamQuery{RefId: "A", Query: "SELECT 1"}
+	ticker := time.NewTicker(time.Hour)
+	defer ticker.Stop()
+
+	// nil, not an error: an error makes Grafana re-establish the stream forever.
+	require.NoError(t, ds.runDeltaLoop(context.Background(), &backend.RunStreamRequest{Path: "ds/uid/A"},
+		backend.NewStreamSender(sink), sq, time.Hour, ticker, 1))
+
+	frames := sink.captured()
+	require.Len(t, frames, 1)
+	require.Empty(t, frames[0].Fields)
+	require.Contains(t, frames[0].Meta.Notices[0].Text, "time-scoping macro")
+}
+
+func streamQueryFixture() *streamQuery {
+	return &streamQuery{
+		RefId:        "A",
+		Query:        "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t",
+		Table:        "test",
+		DateTimeCol:  "event_time",
+		DateTimeType: "DATETIME",
+		Interval:     "1s",
+		Format:       "time_series",
+	}
+}
+
+func TestSendFramesWithDedup(t *testing.T) {
+	from := time.Now().Add(-time.Minute)
+	to := time.Now()
+
+	t.Run("query error publishes an error frame", func(t *testing.T) {
+		ds := &ClickHouseDatasource{im: &fakeInstanceManager{settings: &DatasourceSettings{
+			Instance:   backend.DataSourceInstanceSettings{URL: "://bad"},
+			HTTPClient: http.DefaultClient,
+		}}}
+		sink := &capturingSender{}
+		var fp [16]byte
+
+		ds.sendFramesWithDedup(context.Background(), backend.PluginContext{},
+			backend.NewStreamSender(sink), streamQueryFixture(), from, to, &fp, 1)
+
+		frames := sink.captured()
+		require.Len(t, frames, 1)
+		require.Empty(t, frames[0].Fields)
+		require.Equal(t, data.NoticeSeverityError, frames[0].Meta.Notices[0].Severity)
+	})
+
+	t.Run("no rows sends a heartbeat", func(t *testing.T) {
+		ds, _ := newStubDatasource(t)
+		sink := &capturingSender{}
+		var fp [16]byte
+
+		ds.sendFramesWithDedup(context.Background(), backend.PluginContext{},
+			backend.NewStreamSender(sink), streamQueryFixture(), from, to, &fp, 1)
+
+		frames := sink.captured()
+		require.Len(t, frames, 1)
+		require.Equal(t, "heartbeat", frames[0].Name)
+		require.Equal(t, 0, frames[0].Rows())
+	})
+
+	t.Run("data is sent once and deduped by fingerprint", func(t *testing.T) {
+		ds, stub := newStubDatasource(t)
+		row := fmt.Sprintf(`{"t":"%s","v":1}`, to.UTC().Add(-30*time.Second).Format("2006-01-02 15:04:05"))
+		stub.rowsFor = func(int) string { return row }
+		sink := &capturingSender{}
+		var fp [16]byte
+
+		ds.sendFramesWithDedup(context.Background(), backend.PluginContext{},
+			backend.NewStreamSender(sink), streamQueryFixture(), from, to, &fp, 1)
+		ds.sendFramesWithDedup(context.Background(), backend.PluginContext{},
+			backend.NewStreamSender(sink), streamQueryFixture(), from, to, &fp, 2)
+
+		frames := sink.captured()
+		require.Len(t, frames, 1, "unchanged result must be deduped, not resent")
+		require.Equal(t, 1, frames[0].Rows())
+		require.Equal(t, "A", frames[0].RefID)
+		require.Contains(t, frames[0].Meta.Notices[0].Text, "full mode")
+	})
+}
+
+func TestDeltaInitialQueryErrorSendsErrorFrame(t *testing.T) {
+	ds := &ClickHouseDatasource{im: &fakeInstanceManager{settings: &DatasourceSettings{
+		Instance:   backend.DataSourceInstanceSettings{URL: "://bad"},
+		HTTPClient: http.DefaultClient,
+	}}}
+	sink := &capturingSender{}
+	ticker := time.NewTicker(time.Hour)
+	defer ticker.Stop()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // stop right after the initial tick
+
+	require.NoError(t, ds.runDeltaLoop(ctx, &backend.RunStreamRequest{Path: "ds/uid/A"},
+		backend.NewStreamSender(sink), streamQueryFixture(), time.Hour, ticker, 1))
+
+	frames := sink.captured()
+	require.Len(t, frames, 1)
+	require.Empty(t, frames[0].Fields)
+	require.Equal(t, data.NoticeSeverityError, frames[0].Meta.Notices[0].Severity)
+}
+
+// A lookback wider than the window must clamp the delta query to the window start,
+// keeping every query at most windowSpan wide.
+func TestDeltaLookbackClampsToWindowStart(t *testing.T) {
+	ds, stub := newStubDatasource(t)
+	sq := streamQueryFixture()
+	sq.StreamingLookback = 5000 // clamped to maxStreamingLookbackPoints, still >> window
+
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 2500*time.Millisecond)
+	defer cancel()
+
+	require.NoError(t, ds.runDeltaLoop(ctx, &backend.RunStreamRequest{Path: "ds/uid/A"},
+		backend.NewStreamSender(&nopPacketSender{}), sq, 2*time.Second, ticker, 1))
+
+	queries := stub.recorded()
+	require.GreaterOrEqual(t, len(queries), 2, "expected the initial tick plus delta ticks")
+	for i, sql := range queries {
+		from, to := queryRange(t, sql)
+		require.Equal(t, int64(2), to-from, "tick %d: lookback must clamp to the window", i+1)
+	}
+}
+
+// Full mode dispatch through RunStream, including timeRange parsing from the payload.
+func TestRunStreamFullModeRunsFirstTick(t *testing.T) {
+	ds, stub := newStubDatasource(t)
+	payload, err := json.Marshal(map[string]any{
+		"refId":               "A",
+		"query":               "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t",
+		"table":               "test",
+		"dateTimeColDataType": "event_time",
+		"dateTimeType":        "DATETIME",
+		"interval":            "1s",
+		"streamingMode":       "full",
+		"streamingInterval":   60000,
+		"timeRange": map[string]string{
+			"from": time.Now().Add(-time.Hour).UTC().Format(time.RFC3339),
+			"to":   time.Now().UTC().Format(time.RFC3339),
+		},
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	require.NoError(t, ds.RunStream(ctx, &backend.RunStreamRequest{Path: "ds/uid/A", Data: payload},
+		backend.NewStreamSender(&nopPacketSender{})))
+	require.Len(t, stub.recorded(), 1, "the first tick runs immediately, the next one is a minute away")
+}

--- a/pkg/timeutils/time_parsing_test.go
+++ b/pkg/timeutils/time_parsing_test.go
@@ -1,0 +1,33 @@
+package timeutils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTimeRange(t *testing.T) {
+	tests := []struct {
+		name    string
+		from    string
+		to      string
+		wantErr bool
+	}{
+		{"valid", "2024-01-01T00:00:00Z", "2024-01-02T00:00:00Z", false},
+		{"bad from", "not-a-time", "2024-01-02T00:00:00Z", true},
+		{"bad to", "2024-01-01T00:00:00Z", "not-a-time", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			from, to, err := ParseTimeRange(TimeRangeStruct{From: tt.from, To: tt.to})
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), from)
+			require.Equal(t, time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC), to)
+		})
+	}
+}

--- a/src/datasource/adhoc.test.ts
+++ b/src/datasource/adhoc.test.ts
@@ -1,0 +1,206 @@
+import AdHocFilter, { DEFAULT_VALUES_QUERY } from './adhoc';
+
+const makeDatasource = (overrides: any = {}) => ({
+  defaultDatabase: '',
+  adHocHideTableNames: false,
+  adHocValuesQuery: '',
+  metricFindQuery: jest.fn(),
+  ...overrides,
+});
+
+beforeEach(() => {
+  jest.spyOn(console, 'info').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+describe('AdHocFilter constructor', () => {
+  it('filters out system databases when no default database is set', () => {
+    const filter = new AdHocFilter(makeDatasource());
+    expect(filter.query).toContain("database NOT IN ('system','INFORMATION_SCHEMA','information_schema')");
+  });
+
+  it('filters by default database when set', () => {
+    const filter = new AdHocFilter(makeDatasource({ defaultDatabase: 'mydb' }));
+    expect(filter.query).toContain("database = 'mydb'");
+  });
+});
+
+describe('GetTagKeys', () => {
+  it('returns cached keys without querying', async () => {
+    const ds = makeDatasource();
+    const filter = new AdHocFilter(ds);
+    filter.tagKeys = [{ text: 'cached', value: 'cached' }];
+    await expect(filter.GetTagKeys()).resolves.toEqual([{ text: 'cached', value: 'cached' }]);
+    expect(ds.metricFindQuery).not.toHaveBeenCalled();
+  });
+
+  it('uses a custom query when provided', async () => {
+    const ds = makeDatasource();
+    ds.metricFindQuery.mockResolvedValue([]);
+    await new AdHocFilter(ds).GetTagKeys('SELECT custom');
+    expect(ds.metricFindQuery).toHaveBeenCalledWith('SELECT custom');
+  });
+
+  it('builds fully qualified and bare column keys', async () => {
+    const ds = makeDatasource();
+    ds.metricFindQuery.mockResolvedValue([
+      { database: 'db', table: 'tab', name: 'col', type: 'String' },
+      { database: 'db', table: 'tab2', name: 'col', type: 'String' },
+    ]);
+    const keys = await new AdHocFilter(ds).GetTagKeys();
+    expect(keys).toEqual([
+      { text: 'db.tab.col', value: 'db.tab.col' },
+      { text: 'db.tab2.col', value: 'db.tab2.col' },
+      { text: 'col', value: 'col' },
+    ]);
+  });
+
+  it('omits database prefix when defaultDatabase is set', async () => {
+    const ds = makeDatasource({ defaultDatabase: 'db' });
+    ds.metricFindQuery.mockResolvedValue([{ database: 'db', table: 'tab', name: 'col', type: 'String' }]);
+    const keys = await new AdHocFilter(ds).GetTagKeys();
+    expect(keys[0]).toEqual({ text: 'tab.col', value: 'tab.col' });
+  });
+
+  it('extracts Enum values into tagValues', async () => {
+    const ds = makeDatasource();
+    ds.metricFindQuery.mockResolvedValue([
+      { database: 'db', table: 'tab', name: 'status', type: "Enum8('ok' = 1, 'fail' = 2)" },
+    ]);
+    const filter = new AdHocFilter(ds);
+    await filter.GetTagKeys();
+    expect(filter.tagValues['db.tab.status']).toEqual([
+      { text: "'ok'", value: "'ok'" },
+      { text: "'fail'", value: "'fail'" },
+    ]);
+    expect(filter.tagValues['status']).toEqual(filter.tagValues['db.tab.status']);
+  });
+
+  it('hides table-qualified keys when adHocHideTableNames is set', async () => {
+    const ds = makeDatasource({ adHocHideTableNames: true });
+    ds.metricFindQuery.mockResolvedValue([{ database: 'db', table: 'tab', name: 'col', type: 'String' }]);
+    const keys = await new AdHocFilter(ds).GetTagKeys();
+    expect(keys).toEqual([{ text: 'col', value: 'col' }]);
+  });
+
+  it('returns [] on permission errors', async () => {
+    const ds = makeDatasource();
+    ds.metricFindQuery.mockRejectedValue({ data: { exception: 'ACCESS_DENIED' } });
+    await expect(new AdHocFilter(ds).GetTagKeys()).resolves.toEqual([]);
+  });
+
+  it('rethrows non-permission errors', async () => {
+    const ds = makeDatasource();
+    ds.metricFindQuery.mockRejectedValue(new Error('network down'));
+    await expect(new AdHocFilter(ds).GetTagKeys()).rejects.toThrow('network down');
+  });
+});
+
+describe('GetTagValues', () => {
+  it('returns cached values immediately', async () => {
+    const ds = makeDatasource();
+    const filter = new AdHocFilter(ds);
+    filter.tagValues['db.tab.col'] = [{ text: 'v', value: 'v' }];
+    await expect(filter.GetTagValues({ key: 'db.tab.col' })).resolves.toEqual([{ text: 'v', value: 'v' }]);
+    expect(ds.metricFindQuery).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['single segment', 'bare'],
+    ['two segments without defaultDatabase', 'tab.col'],
+    ['four segments', 'a.b.c.d'],
+  ])('returns [] for invalid key: %s', async (_name, key) => {
+    await expect(new AdHocFilter(makeDatasource()).GetTagValues({ key })).resolves.toEqual([]);
+  });
+
+  it('queries distinct values for a three-part key', async () => {
+    const ds = makeDatasource();
+    ds.metricFindQuery.mockResolvedValue([{ text: 'v1' }, { text: 'v2' }]);
+    const values = await new AdHocFilter(ds).GetTagValues({ key: 'db.tab.col' });
+    expect(ds.metricFindQuery).toHaveBeenCalledWith('SELECT DISTINCT col AS value FROM db.tab LIMIT 300');
+    expect(values).toEqual([
+      { text: 'v1', value: 'v1' },
+      { text: 'v2', value: 'v2' },
+    ]);
+  });
+
+  it('uses defaultDatabase for a two-part key', async () => {
+    const ds = makeDatasource({ defaultDatabase: 'db' });
+    ds.metricFindQuery.mockResolvedValue([]);
+    await new AdHocFilter(ds).GetTagValues({ key: 'tab.col' });
+    expect(ds.metricFindQuery).toHaveBeenCalledWith('SELECT DISTINCT col AS value FROM db.tab LIMIT 300');
+  });
+
+  it('uses custom adHocValuesQuery template', async () => {
+    const ds = makeDatasource({ adHocValuesQuery: 'SELECT {field} FROM {database}.{table} WHERE 1' });
+    ds.metricFindQuery.mockResolvedValue([]);
+    await new AdHocFilter(ds).GetTagValues({ key: 'db.tab.col' });
+    expect(ds.metricFindQuery).toHaveBeenCalledWith('SELECT col FROM db.tab WHERE 1');
+  });
+
+  it('caches [] when the value query fails', async () => {
+    const ds = makeDatasource();
+    ds.metricFindQuery.mockRejectedValue(new Error('boom'));
+    const filter = new AdHocFilter(ds);
+    await expect(filter.GetTagValues({ key: 'db.tab.col' })).resolves.toEqual([]);
+    expect(filter.tagValues['db.tab.col']).toEqual([]);
+  });
+});
+
+describe('GetTagValues with adHocHideTableNames', () => {
+  it('unions per-table value queries from system.columns lookup', async () => {
+    const ds = makeDatasource({ adHocHideTableNames: true });
+    ds.metricFindQuery
+      .mockResolvedValueOnce([
+        { name: 'col', database: 'db1', table: 't1' },
+        { name: 'col', database: 'db2', table: 't2' },
+      ])
+      .mockResolvedValueOnce([{ text: 'v' }]);
+    const values = await new AdHocFilter(ds).GetTagValues({ key: 'col' });
+    expect(ds.metricFindQuery).toHaveBeenNthCalledWith(
+      1,
+      "SELECT name,database,table FROM system.columns WHERE name='col'"
+    );
+    expect(ds.metricFindQuery).toHaveBeenNthCalledWith(
+      2,
+      '(SELECT DISTINCT col AS value FROM db1.t1 LIMIT 300) UNION ALL (SELECT DISTINCT col AS value FROM db2.t2 LIMIT 300)'
+    );
+    expect(values).toEqual([{ text: 'v', value: 'v' }]);
+  });
+
+  it('returns [] when the system.columns lookup hits a permission error', async () => {
+    const ds = makeDatasource({ adHocHideTableNames: true });
+    ds.metricFindQuery.mockRejectedValue({ data: { exception: 'ACCESS_DENIED' } });
+    await expect(new AdHocFilter(ds).GetTagValues({ key: 'col' })).resolves.toEqual([]);
+  });
+
+  it('returns [] when the system.columns lookup fails generically', async () => {
+    const ds = makeDatasource({ adHocHideTableNames: true });
+    ds.metricFindQuery.mockRejectedValue(new Error('boom'));
+    await expect(new AdHocFilter(ds).GetTagValues({ key: 'col' })).resolves.toEqual([]);
+  });
+
+  it('returns [] when the union value query fails', async () => {
+    const ds = makeDatasource({ adHocHideTableNames: true });
+    ds.metricFindQuery
+      .mockResolvedValueOnce([{ name: 'col', database: 'db', table: 't' }])
+      .mockRejectedValueOnce(new Error('boom'));
+    await expect(new AdHocFilter(ds).GetTagValues({ key: 'col' })).resolves.toEqual([]);
+  });
+});
+
+describe('processTagValuesResponse', () => {
+  it('maps text to text/value pairs', async () => {
+    const filter = new AdHocFilter(makeDatasource());
+    await expect(filter.processTagValuesResponse([{ text: 'a' }, { text: 'b' }])).resolves.toEqual([
+      { text: 'a', value: 'a' },
+      { text: 'b', value: 'b' },
+    ]);
+  });
+});
+
+it('exports the default values query template', () => {
+  expect(DEFAULT_VALUES_QUERY).toBe('SELECT DISTINCT {field} AS value FROM {database}.{table} LIMIT 300');
+});

--- a/src/datasource/datasource.execute.test.ts
+++ b/src/datasource/datasource.execute.test.ts
@@ -1,0 +1,217 @@
+jest.mock('@grafana/runtime', () => ({
+  getBackendSrv: jest.fn(() => ({})),
+  getTemplateSrv: jest.fn(),
+  getGrafanaLiveSrv: jest.fn(),
+  config: { bootData: { user: { login: '' } } },
+  DataSourceWithBackend: class {},
+}));
+jest.mock('../views/QueryEditor/QueryEditor', () => ({
+  QueryEditor: () => null,
+  QueryEditorVariable: () => null,
+}));
+jest.mock('../utils/indexedDBManager', () => ({
+  IndexedDBManager: { cleanupAllExpired: jest.fn().mockResolvedValue({ removedKeys: 0 }) },
+}));
+
+import { getBackendSrv, getGrafanaLiveSrv, getTemplateSrv } from '@grafana/runtime';
+import { firstValueFrom } from 'rxjs';
+import { CHDataSource } from './datasource';
+
+// fetch mock in the subscribe style _request expects: next receives {data: <json string>}
+const fetchResponding = (body: any) => jest.fn(() => ({ subscribe: (next: any) => next(body) }));
+const fetchFailing = (error: any) => jest.fn(() => ({ subscribe: (_next: any, err: any) => err(error) }));
+
+let fetchMock: jest.Mock;
+
+beforeEach(() => {
+  fetchMock = fetchResponding({ data: '{"rows":0,"meta":[],"data":[]}' });
+  (getBackendSrv as jest.Mock).mockImplementation(() => ({ fetch: (...args: any[]) => fetchMock(...args) }));
+  (getTemplateSrv as jest.Mock).mockReturnValue({
+    replace: (q: string) => q,
+    getVariables: () => [],
+  });
+});
+
+const makeDatasource = () =>
+  new CHDataSource({ uid: 'UID', url: 'http://localhost:8123', meta: { id: 'x' }, jsonData: {} } as any);
+
+const range = {
+  from: { toISOString: () => '2024-01-01T00:00:00.000Z', valueOf: () => 1704067200000 },
+  to: { toISOString: () => '2024-01-01T01:00:00.000Z', valueOf: () => 1704070800000 },
+};
+
+describe('_request', () => {
+  it('parses the body losslessly, preserving >2^53 integers', async () => {
+    fetchMock = fetchResponding({ data: '{"data":[{"v":11189782786942380395}]}' });
+    const result: any = await makeDatasource()._request('SELECT v');
+    expect(result.data[0].v).toBe('11189782786942380395');
+  });
+
+  it('resolves null for an empty body', async () => {
+    fetchMock = fetchResponding({ data: '' });
+    await expect(makeDatasource()._request('SELECT 1')).resolves.toBeNull();
+  });
+
+  it('rejects with context when the body is unparseable', async () => {
+    fetchMock = fetchResponding({ data: '<html>error</html>' });
+    await expect(makeDatasource()._request('SELECT 1', 'rid')).rejects.toMatchObject({
+      query: 'SELECT 1',
+      requestId: 'rid',
+      originalError: expect.any(Error),
+    });
+  });
+
+  it('rejects transport errors with the string body parsed back to an object', async () => {
+    fetchMock = fetchFailing({ status: 403, data: '{"exception":"ACCESS_DENIED"}' });
+    await expect(makeDatasource()._request('SELECT 1')).rejects.toMatchObject({
+      status: 403,
+      data: { exception: 'ACCESS_DENIED' },
+      query: 'SELECT 1',
+    });
+  });
+});
+
+describe('seriesQuery', () => {
+  it('appends FORMAT JSON', async () => {
+    const ds = makeDatasource();
+    const requestSpy = jest.spyOn(ds, '_request').mockResolvedValue(null);
+    await (ds as any).seriesQuery('SELECT 1', 'rid');
+    expect(requestSpy).toHaveBeenCalledWith('SELECT 1 FORMAT JSON', 'rid');
+  });
+});
+
+describe('executeQueries', () => {
+  const setup = () => {
+    const ds = makeDatasource();
+    ds.options = { range, panelId: 1, scopedVars: {} };
+    jest.spyOn(ds, 'createQuery').mockResolvedValue({ keys: [], requestId: 'r', stmt: 'SELECT 1' });
+    return ds;
+  };
+
+  it('returns empty data for no targets', async () => {
+    await expect(makeDatasource().executeQueries([], {})).resolves.toEqual({ data: [] });
+  });
+
+  it('feeds responses into processQueryResponse', async () => {
+    const ds = setup();
+    jest.spyOn(ds as any, 'seriesQuery').mockResolvedValue({ rows: 1 });
+    const processSpy = jest.spyOn(ds, 'processQueryResponse').mockReturnValue({ data: ['done'] });
+    const options = { targets: [{ refId: 'A' }] };
+    await expect(ds.executeQueries([{ refId: 'A' }], options)).resolves.toEqual({ data: ['done'] });
+    expect(processSpy).toHaveBeenCalledWith([{ rows: 1 }], options, [{ keys: [], requestId: 'r', stmt: 'SELECT 1' }]);
+  });
+
+  it.each([
+    [{ data: { exception: 'DB::Exception' } }, 'Query execution failed: DB::Exception'],
+    [{ data: { message: 'bad query' } }, 'Query execution failed: bad query'],
+    [{ status: 500, statusText: 'ISE', data: 'body text' }, 'Query execution failed: HTTP 500 ISE: body text'],
+    [{ status: 502, statusText: 'BG', data: { k: 1 } }, 'Query execution failed: HTTP 502 BG: {"k":1}'],
+  ])('maps error %j to a descriptive message', async (error, message) => {
+    const ds = setup();
+    jest.spyOn(ds as any, 'seriesQuery').mockRejectedValue(error);
+    await expect(ds.executeQueries([{ refId: 'A' }], {})).rejects.toThrow(message);
+  });
+
+  it('rethrows errors without recognizable shape', async () => {
+    const ds = setup();
+    const bare = new Error('plain');
+    jest.spyOn(ds as any, 'seriesQuery').mockRejectedValue(bare);
+    await expect(ds.executeQueries([{ refId: 'A' }], {})).rejects.toBe(bare);
+  });
+});
+
+describe('query', () => {
+  it('filters hidden and empty targets before executing', async () => {
+    const ds = makeDatasource();
+    const executeSpy = jest.spyOn(ds, 'executeQueries').mockResolvedValue({ data: [] });
+    const options: any = { targets: [{ hide: true, query: 'SELECT 1' }, { query: '   ' }, {}], range };
+    await firstValueFrom(ds.query(options));
+    expect(executeSpy).toHaveBeenCalledWith([], options);
+  });
+
+  it('emits executeQueries result for regular targets', async () => {
+    const ds = makeDatasource();
+    jest.spyOn(ds, 'executeQueries').mockResolvedValue({ data: ['R'] });
+    const options: any = { targets: [{ refId: 'A', query: 'SELECT 1' }], range };
+    await expect(firstValueFrom(ds.query(options))).resolves.toEqual({ data: ['R'] });
+  });
+
+  it('propagates executeQueries failures', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const ds = makeDatasource();
+    jest.spyOn(ds, 'executeQueries').mockRejectedValue(new Error('boom'));
+    const options: any = { targets: [{ refId: 'A', query: 'SELECT 1' }], range };
+    await expect(firstValueFrom(ds.query(options))).rejects.toThrow('boom');
+  });
+
+  describe('streaming', () => {
+    let observer: any;
+    let unsubscribed: boolean;
+
+    beforeEach(() => {
+      observer = null;
+      unsubscribed = false;
+      (getGrafanaLiveSrv as jest.Mock).mockReturnValue({
+        getDataStream: () => ({
+          subscribe: (obs: any) => {
+            observer = obs;
+            return { unsubscribe: () => (unsubscribed = true) };
+          },
+        }),
+      });
+    });
+
+    const streamingOptions: any = {
+      targets: [{ refId: 'A', query: 'SELECT 1', streaming: true }],
+      range,
+      scopedVars: {},
+      interval: '30s',
+    };
+
+    it('forwards next, complete and unsubscribes the live stream', () => {
+      const ds = makeDatasource();
+      const received: any[] = [];
+      let completed = false;
+      const sub = ds.query(streamingOptions).subscribe({
+        next: (v: any) => received.push(v),
+        complete: () => (completed = true),
+      });
+      observer.next({ data: ['frame'] });
+      observer.complete();
+      sub.unsubscribe();
+      expect(received).toEqual([{ data: ['frame'] }]);
+      expect(completed).toBe(true);
+      expect(unsubscribed).toBe(true);
+    });
+
+    it('forwards stream errors', () => {
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      const ds = makeDatasource();
+      let seen: any = null;
+      ds.query(streamingOptions).subscribe({ error: (e: any) => (seen = e) });
+      observer.error(new Error('live failed'));
+      expect(seen).toEqual(new Error('live failed'));
+    });
+
+    it('merges streaming and regular targets into one observable', (done) => {
+      const ds = makeDatasource();
+      jest.spyOn(ds, 'executeQueries').mockResolvedValue({ data: ['regular'] });
+      const options: any = {
+        ...streamingOptions,
+        targets: [...streamingOptions.targets, { refId: 'B', query: 'SELECT 2' }],
+      };
+      const received: any[] = [];
+      ds.query(options).subscribe({
+        next: (v: any) => {
+          received.push(v);
+          if (received.length === 2) {
+            expect(received).toContainEqual({ data: ['stream'] });
+            expect(received).toContainEqual({ data: ['regular'] });
+            done();
+          }
+        },
+      });
+      observer.next({ data: ['stream'] });
+    });
+  });
+});

--- a/src/datasource/datasource.logcontext.test.ts
+++ b/src/datasource/datasource.logcontext.test.ts
@@ -1,0 +1,104 @@
+jest.mock('@grafana/runtime', () => ({
+  getBackendSrv: jest.fn(() => ({})),
+  getTemplateSrv: jest.fn(),
+  getGrafanaLiveSrv: jest.fn(),
+  config: { bootData: { user: { login: '' } } },
+  DataSourceWithBackend: class {},
+}));
+jest.mock('../views/QueryEditor/QueryEditor', () => ({
+  QueryEditor: () => null,
+  QueryEditorVariable: () => null,
+}));
+jest.mock('../utils/indexedDBManager', () => ({
+  IndexedDBManager: { cleanupAllExpired: jest.fn().mockResolvedValue({ removedKeys: 0 }) },
+}));
+
+import { getTemplateSrv } from '@grafana/runtime';
+import { LogRowContextQueryDirection } from '@grafana/data';
+import { CHDataSource } from './datasource';
+
+beforeEach(() => {
+  (getTemplateSrv as jest.Mock).mockReturnValue({ replace: (q: string) => q, getVariables: () => [] });
+});
+
+const logsResponse = {
+  rows: 1,
+  meta: [
+    { name: 'ts', type: 'DateTime' },
+    { name: 'content', type: 'String' },
+  ],
+  data: [{ ts: '2024-01-01 00:00:00', content: 'line' }],
+};
+
+const row: any = { timeEpochMs: 1704067200123, timeUtc: '2024-01-01 00:00:00' };
+const chQuery: any = { dateTimeColDataType: 'ts', contextWindowSize: 10, query: 'SELECT * FROM logs' };
+
+// createQuery echoes the target query as stmt so we can inspect the generated SQL per call
+const setup = (where: string[] = ["host='web'"], responses?: any[]) => {
+  const ds = new CHDataSource({ uid: 'UID', url: 'http://x', meta: { id: 'x' }, jsonData: {} } as any);
+  ds.options = { range: {} };
+  const queries: string[] = [];
+  jest.spyOn(ds, 'createQuery').mockImplementation(async (_o: any, target: any) => {
+    queries.push(target.query);
+    return { keys: [], requestId: 'R', stmt: target.query };
+  });
+  ds.resourceClient = {
+    getMultipleAstProperties: jest.fn(async () => ({ properties: { select: ['a', 'b'], where } })),
+  } as any;
+  const seriesQuery = jest.spyOn(ds as any, 'seriesQuery');
+  (responses ?? [{ data: [{ timestamp: 'TS_BOUND' }] }, logsResponse]).forEach((r) => seriesQuery.mockResolvedValueOnce(r));
+  return { ds, queries };
+};
+
+describe('getLogRowContext', () => {
+  it('generates backward boundary and context SQL', async () => {
+    const { ds, queries } = setup();
+    const result = await ds.getLogRowContext(row, { direction: LogRowContextQueryDirection.Backward }, chQuery);
+
+    // boundaries query: FIRST_VALUE window over ts, 13-digit epoch -> toDateTime64
+    expect(queries[1]).toContain('FIRST_VALUE(ts)');
+    expect(queries[1]).toContain('10 PRECEDING');
+    expect(queries[1]).toContain("WHERE host='web'");
+    expect(queries[1]).toContain('WHERE ts = toDateTime64(1704067200123/1000,3)');
+    // context query: rows between the boundary and the current row
+    expect(queries[2]).toBe(
+      "SELECT a,b FROM $table WHERE host='web' AND ts > 'TS_BOUND' AND ts < '2024-01-01 00:00:00'"
+    );
+    expect(result.data).toHaveLength(1);
+  });
+
+  it('generates forward boundary and context SQL', async () => {
+    const { ds, queries } = setup();
+    await ds.getLogRowContext(row, { direction: LogRowContextQueryDirection.Forward }, chQuery);
+
+    expect(queries[1]).toContain('LAST_VALUE(ts)');
+    expect(queries[1]).toContain('10 FOLLOWING');
+    expect(queries[2]).toBe("SELECT a,b FROM $table WHERE host='web' AND ts <'TS_BOUND' AND ts > '2024-01-01 00:00:00'");
+  });
+
+  it('uses timeUtc for second-precision timestamps', async () => {
+    const { ds, queries } = setup();
+    await ds.getLogRowContext({ ...row, timeEpochMs: 1704067200 }, { direction: LogRowContextQueryDirection.Backward }, chQuery);
+    expect(queries[1]).toContain("WHERE ts = '2024-01-01 00:00:00'");
+  });
+
+  it('omits the where prefix when the query has no where clause', async () => {
+    const { ds, queries } = setup([]);
+    await ds.getLogRowContext(row, { direction: LogRowContextQueryDirection.Backward }, chQuery);
+    expect(queries[2]).toBe("SELECT a,b FROM $table WHERE  ts > 'TS_BOUND' AND ts < '2024-01-01 00:00:00'");
+  });
+
+  it('returns empty data when the context query yields no rows', async () => {
+    const { ds } = setup(undefined as any, [{ data: [{ timestamp: 'TS' }] }, { data: [], meta: [] }]);
+    await expect(
+      ds.getLogRowContext(row, { direction: LogRowContextQueryDirection.Backward }, chQuery)
+    ).resolves.toEqual({ data: [] });
+  });
+
+  it('throws when the context query returns nothing', async () => {
+    const { ds } = setup(undefined as any, [{ data: [{ timestamp: 'TS' }] }, null]);
+    await expect(ds.getLogRowContext(row, { direction: LogRowContextQueryDirection.Backward }, chQuery)).rejects.toThrow(
+      'No response for log context query'
+    );
+  });
+});

--- a/src/datasource/datasource.methods.test.ts
+++ b/src/datasource/datasource.methods.test.ts
@@ -1,0 +1,256 @@
+jest.mock('@grafana/runtime', () => ({
+  getBackendSrv: jest.fn(() => ({})),
+  getTemplateSrv: jest.fn(),
+  getGrafanaLiveSrv: jest.fn(),
+  config: { bootData: { user: { login: '' } } },
+  DataSourceWithBackend: class {},
+}));
+jest.mock('../views/QueryEditor/QueryEditor', () => ({
+  QueryEditor: () => null,
+  QueryEditorVariable: () => null,
+}));
+jest.mock('../utils/indexedDBManager', () => ({
+  IndexedDBManager: { cleanupAllExpired: jest.fn().mockResolvedValue({ removedKeys: 0 }) },
+}));
+
+import { getTemplateSrv } from '@grafana/runtime';
+import { VariableSupportType } from '@grafana/data';
+import { CHDataSource } from './datasource';
+
+let templateSrvMock: any;
+
+beforeEach(() => {
+  templateSrvMock = {
+    replace: jest.fn((q: string) => q),
+    getVariables: jest.fn(() => []),
+    containsTemplate: jest.fn(() => true),
+  };
+  (getTemplateSrv as jest.Mock).mockReturnValue(templateSrvMock);
+});
+
+const makeDatasource = (jsonData: any = {}) =>
+  new CHDataSource({ uid: 'UID', url: 'http://localhost:8123', meta: { id: 'x' }, jsonData } as any);
+
+describe('toggleQueryFilter', () => {
+  const baseQuery: any = { query: 'SELECT 1', adHocFilters: [] };
+
+  it('adds an equality filter for FILTER_FOR', () => {
+    const result = makeDatasource().toggleQueryFilter(baseQuery, {
+      type: 'FILTER_FOR',
+      options: { key: 'host', value: 'a' },
+    });
+    expect(result.adHocFilters).toEqual([{ key: 'host', value: 'a', operator: '=' }]);
+  });
+
+  it('removes an existing FILTER_FOR filter', () => {
+    const query: any = { query: 'SELECT 1', adHocFilters: [{ key: 'host', value: 'a', operator: '=' }] };
+    const result = makeDatasource().toggleQueryFilter(query, {
+      type: 'FILTER_FOR',
+      options: { key: 'host', value: 'a', operator: '=' },
+    });
+    expect(result.adHocFilters).toEqual([]);
+  });
+
+  it('adds a != filter for FILTER_OUT', () => {
+    const result = makeDatasource().toggleQueryFilter(baseQuery, {
+      type: 'FILTER_OUT',
+      options: { key: 'host', value: 'a' },
+    });
+    expect(result.adHocFilters).toEqual([{ key: 'host', value: 'a', operator: '!=' }]);
+  });
+
+  it('removes an existing FILTER_OUT filter', () => {
+    const query: any = { query: 'SELECT 1', adHocFilters: [{ key: 'host', value: 'a', operator: '!=' }] };
+    const result = makeDatasource().toggleQueryFilter(query, {
+      type: 'FILTER_OUT',
+      options: { key: 'host', value: 'a', operator: '!=' },
+    });
+    expect(result.adHocFilters).toEqual([]);
+  });
+
+  it('ignores unknown filter types', () => {
+    const result = makeDatasource().toggleQueryFilter(baseQuery, { type: 'OTHER', options: { key: 'k', value: 'v' } });
+    expect(result.adHocFilters).toEqual([]);
+  });
+});
+
+describe('queryHasFilter', () => {
+  it('matches on key and value', () => {
+    const ds = makeDatasource();
+    const query: any = { adHocFilters: [{ key: 'host', value: 'a', operator: '=' }] };
+    expect(ds.queryHasFilter(query, { key: 'host', value: 'a' } as any)).toBe(true);
+    expect(ds.queryHasFilter(query, { key: 'host', value: 'b' } as any)).toBe(false);
+  });
+});
+
+describe('interpolateVariablesInQueries', () => {
+  it('passes empty arrays through', () => {
+    expect(makeDatasource().interpolateVariablesInQueries([], {})).toEqual([]);
+  });
+
+  it('interpolates and attaches the datasource ref', () => {
+    templateSrvMock.replace = jest.fn(() => 'SELECT interpolated');
+    const result = makeDatasource().interpolateVariablesInQueries([{ query: 'SELECT $var' }], {});
+    expect(result[0].query).toBe('SELECT interpolated');
+    expect(result[0].datasource).toEqual({ type: undefined, uid: 'UID' });
+  });
+
+  it('protects the $adhoc macro from templateSrv', () => {
+    templateSrvMock.replace = jest.fn((q: string) => q.replace(/\$adhoc/g, "'oops'"));
+    const result = makeDatasource().interpolateVariablesInQueries([{ query: 'SELECT * WHERE $adhoc' }], {});
+    expect(result[0].query).toBe('SELECT * WHERE $adhoc');
+  });
+
+  it('applies conditionalTest before interpolation', () => {
+    templateSrvMock.getVariables = jest.fn(() => [{ name: 'v', type: 'textbox', current: { value: '' } }]);
+    const result = makeDatasource().interpolateVariablesInQueries(
+      [{ query: 'SELECT 1 WHERE $conditionalTest(x=1, $v)' }],
+      {}
+    );
+    expect(result[0].query).not.toContain('$conditionalTest');
+    expect(result[0].query).not.toContain('x=1');
+  });
+});
+
+describe('misc accessors', () => {
+  it('getRef returns the uid', () => {
+    expect(makeDatasource().getRef()).toEqual({ type: undefined, uid: 'UID' });
+  });
+
+  it('targetContainsTemplate delegates to templateSrv', () => {
+    expect(makeDatasource().targetContainsTemplate({ query: 'SELECT $x' } as any)).toBe(true);
+    expect(templateSrvMock.containsTemplate).toHaveBeenCalledWith('SELECT $x');
+  });
+
+  it('getTagKeys forwards the adhoc_query_filter variable query', () => {
+    templateSrvMock.getVariables = jest.fn(() => [{ name: 'adhoc_query_filter', query: 'SELECT cols', type: 'query' }]);
+    const ds = makeDatasource();
+    const spy = jest.spyOn(ds.adHocFilter, 'GetTagKeys').mockResolvedValue([]);
+    ds.getTagKeys();
+    expect(spy).toHaveBeenCalledWith('SELECT cols');
+  });
+
+  it('getTagKeys passes empty filter without the variable', () => {
+    const ds = makeDatasource();
+    const spy = jest.spyOn(ds.adHocFilter, 'GetTagKeys').mockResolvedValue([]);
+    ds.getTagKeys();
+    expect(spy).toHaveBeenCalledWith('');
+  });
+
+  it('getTagValues delegates to the adhoc filter', () => {
+    const ds = makeDatasource();
+    const spy = jest.spyOn(ds.adHocFilter, 'GetTagValues').mockResolvedValue([]);
+    ds.getTagValues({ key: 'a.b.c' });
+    expect(spy).toHaveBeenCalledWith({ key: 'a.b.c' });
+  });
+});
+
+describe('constructor configuration', () => {
+  it('builds defaultValues when useDefaultConfiguration is set', () => {
+    const ds = makeDatasource({
+      useDefaultConfiguration: true,
+      defaultDateTime64: 'dt64',
+      defaultDateTime: 'dt',
+      defaultDateTimeType: 'DATETIME64',
+      contextWindowSize: 20,
+      nullifySparse: true,
+    });
+    expect(ds.defaultValues.dateTime.defaultDateTime64).toBe('dt64');
+    expect(ds.defaultValues.dateTime.defaultDateTime).toBe('dt');
+    expect(ds.defaultValues.defaultDateTimeType).toBe('DATETIME64');
+    expect(ds.defaultValues.contextWindowSize).toBe(20);
+    expect(ds.defaultValues.nullifySparse).toBe(true);
+  });
+
+  it('leaves defaultValues unset otherwise', () => {
+    expect(makeDatasource().defaultValues).toBeUndefined();
+  });
+
+  it('registers custom variable support', () => {
+    const ds = makeDatasource();
+    expect((ds.variables as any).getType()).toBe(VariableSupportType.Custom);
+  });
+});
+
+describe('_getRequestOptions', () => {
+  const base = { url: 'http://localhost:8123' };
+
+  it('uses POST with the query as body', () => {
+    const opts = CHDataSource._getRequestOptions('SELECT 1', true, 'r1', base);
+    expect(opts.method).toBe('POST');
+    expect(opts.data).toBe('SELECT 1');
+    expect(opts.url).toBe('http://localhost:8123');
+  });
+
+  it('uses GET with the query url-encoded', () => {
+    const opts = CHDataSource._getRequestOptions('SELECT 1', false, 'r1', base);
+    expect(opts.method).toBe('GET');
+    expect(opts.url).toBe('http://localhost:8123/?query=' + encodeURIComponent('SELECT 1'));
+  });
+
+  it('adds the database param', () => {
+    const opts = CHDataSource._getRequestOptions('q', true, 'r', { ...base, defaultDatabase: 'db' });
+    expect(opts.url).toContain('/?database=db');
+  });
+
+  it('sets credentials and Authorization for basicAuth', () => {
+    const opts = CHDataSource._getRequestOptions('q', true, 'r', { ...base, basicAuth: 'Basic xyz' });
+    expect(opts.withCredentials).toBe(true);
+    expect(opts.headers.Authorization).toBe('Basic xyz');
+  });
+
+  it('sets credentials for withCredentials alone', () => {
+    const opts = CHDataSource._getRequestOptions('q', true, 'r', { ...base, withCredentials: true });
+    expect(opts.withCredentials).toBe(true);
+    expect(opts.headers.Authorization).toBeUndefined();
+  });
+
+  it('adds compression header and param', () => {
+    const opts = CHDataSource._getRequestOptions('q', true, 'r', { ...base, useCompression: true, compressionType: 'gzip' });
+    expect(opts.headers['Accept-Encoding']).toBe('gzip');
+    expect(opts.url).toContain('enable_http_compression=1');
+  });
+
+  it('appends /xHeaderKey for Yandex auth without SSL cert', () => {
+    const opts = CHDataSource._getRequestOptions('q', true, 'r', {
+      ...base,
+      useYandexCloudAuthorization: true,
+      xHeaderUser: 'user1',
+    });
+    expect(opts.headers['X-ClickHouse-User']).toBe('user1');
+    expect(opts.url).toBe('http://localhost:8123/xHeaderKey');
+  });
+
+  it('appends /xClickHouseSSLCertificateAuth with SSL cert auth', () => {
+    const opts = CHDataSource._getRequestOptions('q', true, 'r', {
+      ...base,
+      useYandexCloudAuthorization: true,
+      xClickHouseSSLCertificateAuth: true,
+      xHeaderUser: 'user1',
+    });
+    expect(opts.headers['X-ClickHouse-SSL-Certificate-Auth']).toBe('on');
+    expect(opts.url).toBe('http://localhost:8123/xClickHouseSSLCertificateAuth');
+  });
+
+  it.each([[true], [false]])(
+    'does not append a suffix when the url already contains /? (ssl=%s)',
+    (ssl) => {
+      const opts = CHDataSource._getRequestOptions('q', true, 'r', {
+        url: 'http://localhost:8123/?foo=1',
+        useYandexCloudAuthorization: true,
+        xClickHouseSSLCertificateAuth: ssl,
+      });
+      expect(opts.url).toBe('http://localhost:8123/?foo=1');
+    }
+  );
+
+  it('adds the CORS param', () => {
+    const opts = CHDataSource._getRequestOptions('q', true, 'r', { ...base, addCorsHeader: true });
+    expect(opts.url).toContain('add_http_cors_header=1');
+  });
+
+  it('joins params with & when the url already has a query string', () => {
+    const opts = CHDataSource._getRequestOptions('q', true, 'r', { url: 'http://localhost:8123/?a=1', addCorsHeader: true });
+    expect(opts.url).toBe('http://localhost:8123/?a=1&add_http_cors_header=1');
+  });
+});

--- a/src/datasource/datasource.replace.test.ts
+++ b/src/datasource/datasource.replace.test.ts
@@ -1,0 +1,253 @@
+jest.mock('@grafana/runtime', () => ({
+  getBackendSrv: jest.fn(() => ({})),
+  getTemplateSrv: jest.fn(),
+  getGrafanaLiveSrv: jest.fn(),
+  config: { bootData: { user: { login: '' } } },
+  DataSourceWithBackend: class {},
+}));
+jest.mock('../views/QueryEditor/QueryEditor', () => ({
+  QueryEditor: () => null,
+  QueryEditorVariable: () => null,
+}));
+jest.mock('../utils/indexedDBManager', () => ({
+  IndexedDBManager: { cleanupAllExpired: jest.fn().mockResolvedValue({ removedKeys: 0 }) },
+}));
+
+import { config, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
+import { CHDataSource } from './datasource';
+
+let templateSrvMock: any;
+let fetchMock: jest.Mock;
+
+beforeEach(() => {
+  templateSrvMock = {
+    // substitute $name from scopedVars, leave unknown variables intact
+    replace: jest.fn((target: string, scopedVars?: any) =>
+      (target || '').replace(/\$(\w+)/g, (match: string, name: string) => scopedVars?.[name]?.value ?? match)
+    ),
+    getVariables: jest.fn(() => []),
+  };
+  (getTemplateSrv as jest.Mock).mockReturnValue(templateSrvMock);
+  fetchMock = jest.fn(() => ({ subscribe: (next: any) => next({ data: '{"meta":[],"data":[]}' }) }));
+  (getBackendSrv as jest.Mock).mockImplementation(() => ({ fetch: (...args: any[]) => fetchMock(...args) }));
+  (config as any).bootData.user.login = 'roman';
+});
+
+const makeDatasource = () => {
+  const ds = new CHDataSource({ uid: 'UID', url: 'http://localhost:8123', meta: { id: 'x' }, jsonData: {} } as any);
+  ds.resourceClient = {
+    createQueryWithAdhoc: jest.fn(async (queryData: any) => ({ sql: queryData.query })),
+    getAstProperty: jest.fn(async () => ({ properties: ['host'] })),
+    getMultipleAstProperties: jest.fn(),
+    replaceTimeFilters: jest.fn(async (q: string) => q),
+  } as any;
+  return ds;
+};
+
+const options: any = {
+  panelId: 5,
+  interval: '15s',
+  scopedVars: {},
+  maxDataPoints: 100,
+  range: {
+    from: { toISOString: () => '2024-01-01T00:00:00.000Z', valueOf: () => 1704067200000 },
+    to: { toISOString: () => '2024-01-01T01:00:00.000Z', valueOf: () => 1704070800000 },
+  },
+};
+
+const lastQueryData = (ds: any) =>
+  (ds.resourceClient.createQueryWithAdhoc as jest.Mock).mock.calls.at(-1)[0];
+
+describe('replace', () => {
+  it('substitutes $__searchFilter with % when no search filter is set', async () => {
+    const ds = makeDatasource();
+    await ds.replace(options, { query: "SELECT x WHERE x LIKE '$__searchFilter'" } as any);
+    expect(lastQueryData(ds).query).toBe("SELECT x WHERE x LIKE '%'");
+  });
+
+  it('appends % to an existing scoped search filter', async () => {
+    const ds = makeDatasource();
+    const opts = { ...options, scopedVars: { __searchFilter: { value: 'foo' } } };
+    await ds.replace(opts, { query: "SELECT x WHERE x LIKE '$__searchFilter'" } as any);
+    expect(lastQueryData(ds).query).toBe("SELECT x WHERE x LIKE 'foo%'");
+  });
+
+  it('falls back to % when the backend re-introduces $__searchFilter', async () => {
+    const ds = makeDatasource();
+    (ds.resourceClient.createQueryWithAdhoc as jest.Mock).mockResolvedValue({
+      sql: "SELECT y WHERE y LIKE '$__searchFilter'",
+    });
+    const { stmt } = await ds.replace(options, { query: 'SELECT x' } as any);
+    expect(stmt).toBe("SELECT y WHERE y LIKE '%'");
+  });
+
+  it('keeps the $adhoc macro intact through templateSrv interpolation', async () => {
+    const ds = makeDatasource();
+    templateSrvMock.replace = jest.fn((q: string) => q.replace(/\$adhoc/g, "'broken'"));
+    await ds.replace(options, { query: 'SELECT x WHERE $adhoc' } as any);
+    expect(lastQueryData(ds).query).toBe('SELECT x WHERE $adhoc');
+  });
+
+  it('fills queryData defaults', async () => {
+    const ds = makeDatasource();
+    const opts = { ...options, headers: { 'X-Rule-Uid': 'rule-1' } };
+    await ds.replace(opts, { refId: 'A', query: 'SELECT x' } as any);
+    expect(lastQueryData(ds)).toMatchObject({
+      frontendDatasource: true,
+      refId: 'A',
+      ruleUid: 'rule-1',
+      dateTimeType: 'DATETIME',
+      format: 'time_series',
+      round: '0s',
+      intervalFactor: 1,
+      interval: '15s',
+      database: 'default',
+      maxDataPoints: 100,
+      timeRange: { from: '2024-01-01T00:00:00.000Z', to: '2024-01-01T01:00:00.000Z' },
+      metadataUserLogin: 'roman',
+    });
+  });
+
+  it.each([
+    ['target interval wins', '1m', '1m'],
+    ['falls back to options.interval', undefined, '15s'],
+  ])('interval chain: %s', async (_name, targetInterval, expected) => {
+    const ds = makeDatasource();
+    await ds.replace(options, { query: 'SELECT x', interval: targetInterval } as any);
+    expect(lastQueryData(ds).interval).toBe(expected);
+  });
+
+  it('defaults interval to 30s when neither target nor options define it', async () => {
+    const ds = makeDatasource();
+    await ds.replace({ ...options, interval: undefined }, { query: 'SELECT x' } as any);
+    expect(lastQueryData(ds).interval).toBe('30s');
+  });
+
+  it('throws when the backend reports an error', async () => {
+    const ds = makeDatasource();
+    (ds.resourceClient.createQueryWithAdhoc as jest.Mock).mockResolvedValue({ sql: '', error: 'bad macro' });
+    await expect(ds.replace(options, { query: 'SELECT x' } as any)).rejects.toThrow('bad macro');
+  });
+
+  it('returns group by properties as keys', async () => {
+    const ds = makeDatasource();
+    const result = await ds.replace(options, { query: 'SELECT x' } as any);
+    expect(ds.resourceClient.getAstProperty).toHaveBeenCalledWith('SELECT x', 'group by');
+    expect(result).toEqual({ stmt: 'SELECT x', keys: ['host'] });
+  });
+});
+
+describe('createQuery', () => {
+  it('wraps replace output with a panel-scoped requestId', async () => {
+    const ds = makeDatasource();
+    jest.spyOn(ds, 'replace').mockResolvedValue({ stmt: 'SELECT final', keys: ['k'] });
+    const result = await ds.createQuery(options, { refId: 'A' });
+    expect(result.stmt).toBe('SELECT final');
+    expect(result.keys).toEqual(['k']);
+    expect(result.requestId.startsWith('5A')).toBe(true);
+  });
+
+  it('propagates replace errors', async () => {
+    const ds = makeDatasource();
+    jest.spyOn(ds, 'replace').mockRejectedValue(new Error('nope'));
+    await expect(ds.createQuery(options, { refId: 'A' })).rejects.toThrow('nope');
+  });
+});
+
+describe('annotationQuery', () => {
+  it('throws when the annotation has no query', async () => {
+    await expect(makeDatasource().annotationQuery({ annotation: {} })).rejects.toThrow(
+      'Query missing in annotation definition'
+    );
+  });
+
+  it('flattens newlines, appends FORMAT JSON and transforms the response', async () => {
+    const ds = makeDatasource();
+    jest.spyOn(ds, 'replace').mockResolvedValue({ stmt: 'SELECT time\nFROM anno', keys: [] });
+    const body = JSON.stringify({
+      meta: [{ name: 'time', type: 'UInt64' }],
+      data: [{ time: 1704067200000, title: 'T', text: 'txt', tags: 'a, b' }],
+    });
+    fetchMock = jest.fn(() => ({ subscribe: (next: any) => next({ data: body }) }));
+    const annotation = { query: 'SELECT time FROM anno' };
+    const events: any = await ds.annotationQuery({ annotation, range: options.range });
+    expect(fetchMock.mock.calls[0][0].data).toBe('SELECT time FROM anno FORMAT JSON');
+    expect(events).toEqual([
+      expect.objectContaining({ annotation, time: 1704067200000, title: 'T', text: 'txt', tags: ['a', 'b'] }),
+    ]);
+  });
+
+  it('rejects on unparseable responses', async () => {
+    const ds = makeDatasource();
+    jest.spyOn(ds, 'replace').mockResolvedValue({ stmt: 'SELECT 1', keys: [] });
+    fetchMock = jest.fn(() => ({ subscribe: (next: any) => next({ data: 'not json' }) }));
+    await expect(ds.annotationQuery({ annotation: { query: 'q' }, range: options.range })).rejects.toBeInstanceOf(
+      SyntaxError
+    );
+  });
+
+  it('rejects transport errors with the body parsed back to an object', async () => {
+    const ds = makeDatasource();
+    jest.spyOn(ds, 'replace').mockResolvedValue({ stmt: 'SELECT 1', keys: [] });
+    fetchMock = jest.fn(() => ({
+      subscribe: (_next: any, err: any) => err({ status: 500, data: '{"exception":"boom"}' }),
+    }));
+    await expect(ds.annotationQuery({ annotation: { query: 'q' }, range: options.range })).rejects.toMatchObject({
+      status: 500,
+      data: { exception: 'boom' },
+    });
+  });
+});
+
+describe('metricFindQuery', () => {
+  it('returns [] for empty queries', async () => {
+    await expect(makeDatasource().metricFindQuery('')).resolves.toEqual([]);
+    await expect(makeDatasource().metricFindQuery('   ')).resolves.toEqual([]);
+  });
+
+  it('substitutes $__searchFilter with the search filter plus wildcard', async () => {
+    const ds = makeDatasource();
+    const seriesSpy = jest.spyOn(ds as any, 'seriesQuery').mockResolvedValue({ meta: [], data: [] });
+    await ds.metricFindQuery("SELECT x WHERE x LIKE '$__searchFilter'", { searchFilter: 'foo' });
+    expect(seriesSpy).toHaveBeenCalledWith("SELECT x WHERE x LIKE 'foo%'");
+  });
+
+  it('substitutes $__searchFilter with % without a search filter', async () => {
+    const ds = makeDatasource();
+    const seriesSpy = jest.spyOn(ds as any, 'seriesQuery').mockResolvedValue({ meta: [], data: [] });
+    await ds.metricFindQuery("SELECT x WHERE x LIKE '$__searchFilter'");
+    expect(seriesSpy).toHaveBeenCalledWith("SELECT x WHERE x LIKE '%'");
+  });
+
+  it('replaces $from/$to, applies backend time filters and flattens newlines', async () => {
+    const ds = makeDatasource();
+    (ds.resourceClient.replaceTimeFilters as jest.Mock).mockImplementation(async (q: string) => q + ' /*tf*/');
+    const seriesSpy = jest.spyOn(ds as any, 'seriesQuery').mockResolvedValue({ meta: [], data: [] });
+    await ds.metricFindQuery('SELECT $from,\n$to', { range: options.range, dateTimeType: 'DATETIME' });
+    expect(ds.resourceClient.replaceTimeFilters).toHaveBeenCalledWith(
+      'SELECT 1704067200,\n1704070800',
+      options.range,
+      'DATETIME'
+    );
+    expect(seriesSpy).toHaveBeenCalledWith('SELECT 1704067200, 1704070800 /*tf*/');
+  });
+
+  it('parses the response through responseParser', async () => {
+    const ds = makeDatasource();
+    jest.spyOn(ds as any, 'seriesQuery').mockResolvedValue({ meta: [{ name: 'x' }], data: [{ x: 'v' }] });
+    await expect(ds.metricFindQuery('SELECT x')).resolves.toEqual([{ text: 'v' }]);
+  });
+});
+
+describe('testDatasource', () => {
+  it('reports success when the probe query works', async () => {
+    const ds = makeDatasource();
+    const spy = jest.spyOn(ds, 'metricFindQuery').mockResolvedValue([]);
+    await expect(ds.testDatasource()).resolves.toEqual({
+      status: 'success',
+      message: 'Data source is working',
+      title: 'Success',
+    });
+    expect(spy).toHaveBeenCalledWith('SELECT 1');
+  });
+});

--- a/src/datasource/datasource.response.test.ts
+++ b/src/datasource/datasource.response.test.ts
@@ -1,0 +1,268 @@
+jest.mock('@grafana/runtime', () => ({
+  getBackendSrv: jest.fn(() => ({})),
+  getTemplateSrv: jest.fn(),
+  getGrafanaLiveSrv: jest.fn(),
+  config: { bootData: { user: { login: '' } } },
+  DataSourceWithBackend: class {},
+}));
+jest.mock('../views/QueryEditor/QueryEditor', () => ({
+  QueryEditor: () => null,
+  QueryEditorVariable: () => null,
+}));
+jest.mock('../utils/indexedDBManager', () => ({
+  IndexedDBManager: { cleanupAllExpired: jest.fn().mockResolvedValue({ removedKeys: 0 }) },
+}));
+
+import { getTemplateSrv } from '@grafana/runtime';
+import { firstValueFrom } from 'rxjs';
+import { CHDataSource } from './datasource';
+import { DatasourceMode } from '../types/types';
+
+beforeEach(() => {
+  (getTemplateSrv as jest.Mock).mockReturnValue({
+    replace: (q: string) => q,
+    getVariables: () => [],
+  });
+});
+
+const makeDatasource = () =>
+  new CHDataSource({ uid: 'UID', url: 'http://localhost:8123', meta: { id: 'x' }, jsonData: {} } as any);
+
+const range = { from: new Date('2024-01-01T00:00:00Z'), to: new Date('2024-01-01T01:00:00Z') };
+
+const makeOptions = (target: any) => ({ targets: [target], range, rangeRaw: { to: 'now' } });
+
+const tsResponse = {
+  rows: 2,
+  meta: [
+    { name: 't', type: 'UInt64' },
+    { name: 'good', type: 'UInt64' },
+  ],
+  data: [
+    { t: 1704067200000, good: 1 },
+    { t: 1704067260000, good: 3 },
+  ],
+};
+
+describe('processQueryResponse', () => {
+  it('skips null and rows-less responses', () => {
+    const ds = makeDatasource();
+    const options = { targets: [{ refId: 'A' }, { refId: 'B' }], range, rangeRaw: {} };
+    const result = ds.processQueryResponse([null, { data: [], meta: [] }], options, [{ keys: [] }, { keys: [] }]);
+    expect(result).toEqual({ data: [] });
+  });
+
+  it('renders table format via toTable', () => {
+    const ds = makeDatasource();
+    const result = ds.processQueryResponse([tsResponse], makeOptions({ refId: 'A', format: 'table' }), [{ keys: [] }]);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].columns.map((c: any) => c.text)).toEqual(['t', 'good']);
+    expect(result.data[0].type).toBe('table');
+  });
+
+  it('renders logs format via toLogs', () => {
+    const ds = makeDatasource();
+    const response = {
+      rows: 1,
+      meta: [
+        { name: 'event_time', type: 'DateTime' },
+        { name: 'content', type: 'String' },
+      ],
+      data: [{ event_time: '2024-01-01 00:00:00', content: 'hello' }],
+    };
+    const result = ds.processQueryResponse([response], makeOptions({ refId: 'A', format: 'logs' }), [{ keys: [] }]);
+    expect(result.data).toHaveLength(1);
+    const body = result.data[0].fields.find((f: any) => f.name === 'body');
+    expect(body.values[0] ?? body.values.get(0)).toBe('hello');
+  });
+
+  it('renders annotations for refId Anno', () => {
+    const ds = makeDatasource();
+    const response = {
+      rows: 1,
+      meta: [{ name: 'time', type: 'UInt64' }],
+      data: [{ time: '1704067200000', title: 'T', text: 'txt', tags: 'a,b' }],
+    };
+    const result = ds.processQueryResponse([response], makeOptions({ refId: 'Anno' }), [{ keys: [] }]);
+    const fields = result.data[0].fields;
+    expect(fields.find((f: any) => f.name === 'time').values).toEqual([1704067200000]);
+    expect(fields.find((f: any) => f.name === 'tags').values).toEqual([['a', 'b']]);
+  });
+
+  it('renders traces format via toTraces', () => {
+    const ds = makeDatasource();
+    const response = {
+      rows: 1,
+      meta: [{ name: 'startTime', type: 'UInt64' }],
+      data: [
+        {
+          traceID: 't1',
+          spanID: 's1',
+          parentSpanID: null,
+          serviceName: 'svc',
+          startTime: '1704067200000',
+          duration: 5,
+          operationName: 'op',
+          tags: {},
+          serviceTags: {},
+        },
+      ],
+    };
+    const result = ds.processQueryResponse([response], makeOptions({ refId: 'A', format: 'traces' }), [{ keys: [] }]);
+    expect(result.data[0].fields.find((f: any) => f.name === 'traceID').values).toEqual(['t1']);
+  });
+
+  it('renders flamegraph format via toFlamegraph', () => {
+    const ds = makeDatasource();
+    const response = {
+      rows: 1,
+      meta: [],
+      data: [{ label: 'fn', level: 1, value: '10', self: 10 }],
+    };
+    const result = ds.processQueryResponse([response], makeOptions({ refId: 'A', format: 'flamegraph' }), [
+      { keys: [] },
+    ]);
+    expect(result.data[0].fields.find((f: any) => f.name === 'label').values).toEqual(['all', 'fn']);
+  });
+
+  it('renders time series by default', () => {
+    const ds = makeDatasource();
+    const result = ds.processQueryResponse([tsResponse], makeOptions({ refId: 'A' }), [{ keys: [] }]);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].fields[0].values).toEqual([1704067200000, 1704067260000]);
+    expect(result.data[0].fields[1].values).toEqual([1, 3]);
+  });
+
+  describe('DatasourceMode.Variable branch', () => {
+    const variableTarget = { refId: 'A', datasourceMode: DatasourceMode.Variable };
+    const run = (meta: any[], data: any[]) =>
+      makeDatasource().processQueryResponse([{ rows: data.length || 1, meta, data }], makeOptions(variableTarget), [
+        { keys: [] },
+      ]);
+
+    it('maps text and value columns to two stringified fields', () => {
+      const result = run(
+        [
+          { name: 'my_text', type: 'String' },
+          { name: 'my_value', type: 'UInt64' },
+        ],
+        [{ my_text: 'a', my_value: 1 }]
+      );
+      expect(result.data[0].fields).toEqual([
+        { name: 'text', type: 'string', values: ['a'] },
+        { name: 'value', type: 'string', values: ['1'] },
+      ]);
+    });
+
+    it('maps a lone text column', () => {
+      const result = run([{ name: 'text', type: 'String' }], [{ text: 'a' }]);
+      expect(result.data[0].fields).toEqual([{ name: 'text', type: 'string', values: ['a'] }]);
+    });
+
+    it('falls back to the first String column', () => {
+      const result = run(
+        [
+          { name: 'num', type: 'UInt64' },
+          { name: 'label', type: 'String' },
+        ],
+        [{ num: 1, label: 'x' }]
+      );
+      expect(result.data[0].fields).toEqual([{ name: 'text', type: 'string', values: ['x'] }]);
+    });
+
+    it('falls back to the first meta column when no String column exists', () => {
+      const result = run([{ name: 'num', type: 'UInt64' }], [{ num: 7 }]);
+      expect(result.data[0].fields).toEqual([{ name: 'text', type: 'string', values: [7] }]);
+    });
+
+    it('yields an empty field list for empty meta', () => {
+      const result = run([], []);
+      expect(result.data[0].fields).toEqual([{ name: 'text', type: 'string', values: [] }]);
+    });
+  });
+});
+
+describe('queryVariables', () => {
+  const setup = (response: any) => {
+    const ds = makeDatasource();
+    const createQuery = jest
+      .spyOn(ds, 'createQuery')
+      .mockImplementation(async (_o: any, target: any) => ({ keys: [], requestId: 'r', stmt: target.query }));
+    jest.spyOn(ds as any, 'seriesQuery').mockResolvedValue(response);
+    return { ds, createQuery };
+  };
+
+  const baseOptions: any = { range, rangeRaw: {}, scopedVars: {} };
+
+  it('returns empty data for hidden or empty targets', async () => {
+    const { ds } = setup(null);
+    const inner: any = await firstValueFrom(ds.queryVariables({ ...baseOptions, targets: [{ hide: true, query: 'q' }, { query: '  ' }] }));
+    // empty-target path wraps its result in a nested observable
+    expect(await firstValueFrom(inner)).toEqual({ data: [] });
+  });
+
+  it('coerces a bare string target into a Variable-mode query', async () => {
+    const { ds, createQuery } = setup({
+      rows: 1,
+      meta: [{ name: 'text', type: 'String' }],
+      data: [{ text: 'v' }],
+    });
+    const result: any = await firstValueFrom(ds.queryVariables({ ...baseOptions, targets: ['SELECT x'] } as any));
+    expect(createQuery).toHaveBeenCalledWith(expect.anything(), {
+      query: 'SELECT x',
+      datasourceMode: DatasourceMode.Variable,
+    });
+    expect(result.data[0].fields).toEqual([{ name: 'text', type: 'string', values: ['v'] }]);
+  });
+
+  it('maps text and value columns end-to-end', async () => {
+    const { ds } = setup({
+      rows: 1,
+      meta: [
+        { name: '__text', type: 'String' },
+        { name: '__value', type: 'UInt64' },
+      ],
+      data: [{ __text: 'a', __value: 5 }],
+    });
+    const result: any = await firstValueFrom(ds.queryVariables({ ...baseOptions, targets: [{ refId: 'A', query: 'SELECT x' }] }));
+    expect(result.data[0].fields).toEqual([
+      { name: 'text', type: 'string', values: ['a'] },
+      { name: 'value', type: 'string', values: ['5'] },
+    ]);
+  });
+
+  it('falls back to the first meta column when nothing matches', async () => {
+    const { ds } = setup({
+      rows: 1,
+      meta: [{ name: 'num', type: 'UInt64' }],
+      data: [{ num: 9 }],
+    });
+    const result: any = await firstValueFrom(ds.queryVariables({ ...baseOptions, targets: [{ refId: 'A', query: 'SELECT x' }] }));
+    expect(result.data[0].fields).toEqual([{ name: 'text', type: 'string', values: [9] }]);
+  });
+
+  it('falls back to the first String column', async () => {
+    const { ds } = setup({
+      rows: 1,
+      meta: [
+        { name: 'num', type: 'UInt64' },
+        { name: 'label', type: 'String' },
+      ],
+      data: [{ num: 1, label: 'x' }],
+    });
+    const result: any = await firstValueFrom(ds.queryVariables({ ...baseOptions, targets: [{ refId: 'A', query: 'SELECT x' }] }));
+    expect(result.data[0].fields).toEqual([{ name: 'text', type: 'string', values: ['x'] }]);
+  });
+
+  it('handles rows with empty meta', async () => {
+    const { ds } = setup({ rows: 1, meta: [], data: [] });
+    const result: any = await firstValueFrom(ds.queryVariables({ ...baseOptions, targets: [{ refId: 'A', query: 'SELECT x' }] }));
+    expect(result.data[0].fields).toEqual([{ name: 'text', type: 'string', values: [] }]);
+  });
+
+  it('skips responses without rows', async () => {
+    const { ds } = setup({ meta: [], data: [] });
+    const result: any = await firstValueFrom(ds.queryVariables({ ...baseOptions, targets: [{ refId: 'A', query: 'SELECT x' }] }));
+    expect(result).toEqual({ data: [] });
+  });
+});

--- a/src/datasource/resource_handler.test.ts
+++ b/src/datasource/resource_handler.test.ts
@@ -1,0 +1,106 @@
+jest.mock('@grafana/runtime', () => ({
+  getBackendSrv: jest.fn(),
+}));
+
+import { getBackendSrv } from '@grafana/runtime';
+import { ClickHouseResourceClient } from './resource_handler';
+
+let fetchMock: jest.Mock;
+
+const respondWith = (data: any) => {
+  fetchMock.mockReturnValue({ subscribe: (next: any) => next({ data }) });
+};
+
+const getClient = (uid = 'UID') => {
+  const client = ClickHouseResourceClient.getInstance();
+  client.setDatasourceUid(uid);
+  return client;
+};
+
+beforeEach(() => {
+  fetchMock = jest.fn();
+  (getBackendSrv as jest.Mock).mockReturnValue({ fetch: fetchMock });
+  // singleton captures backendSrv at construction; reset after the mock is in place
+  (ClickHouseResourceClient as any).instance = undefined;
+});
+
+describe('ClickHouseResourceClient', () => {
+  it('returns the same singleton instance', () => {
+    expect(ClickHouseResourceClient.getInstance()).toBe(ClickHouseResourceClient.getInstance());
+  });
+
+  it('rejects when the datasource uid is not set', async () => {
+    await expect(ClickHouseResourceClient.getInstance().createQuery({})).rejects.toThrow('Datasource UID not set');
+  });
+
+  it('POSTs to the datasource resource URL and resolves response.data', async () => {
+    respondWith({ ok: true });
+    await expect(getClient().createQuery({ q: 1 })).resolves.toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledWith({
+      url: '/api/datasources/uid/UID/resources/createQuery',
+      method: 'POST',
+      data: { q: 1 },
+    });
+  });
+
+  it('rejects on transport errors', async () => {
+    fetchMock.mockReturnValue({ subscribe: (_next: any, err: any) => err(new Error('down')) });
+    await expect(getClient().createQuery({})).rejects.toThrow('down');
+  });
+
+  it('applyAdhocFilters unwraps response.query', async () => {
+    respondWith({ query: 'SELECT filtered' });
+    await expect(getClient().applyAdhocFilters('SELECT 1', [{ key: 'k' }], { refId: 'A' })).resolves.toBe(
+      'SELECT filtered'
+    );
+    expect(fetchMock.mock.calls[0][0].data).toEqual({
+      query: 'SELECT 1',
+      adhocFilters: [{ key: 'k' }],
+      target: { refId: 'A' },
+    });
+  });
+
+  it('getAstProperty forwards the property name', async () => {
+    respondWith({ properties: ['host'] });
+    await expect(getClient().getAstProperty('SELECT 1', 'group by')).resolves.toEqual({ properties: ['host'] });
+    expect(fetchMock.mock.calls[0][0].data).toEqual({ query: 'SELECT 1', propertyName: 'group by' });
+  });
+
+  it('replaceTimeFilters sends the range as ISO strings and unwraps response.sql', async () => {
+    respondWith({ sql: 'SELECT tf' });
+    const range = { from: new Date('2024-01-01T00:00:00Z'), to: new Date('2024-01-01T01:00:00Z') };
+    await expect(getClient().replaceTimeFilters('SELECT 1', range, 'DATETIME')).resolves.toBe('SELECT tf');
+    expect(fetchMock.mock.calls[0][0].data).toEqual({
+      query: 'SELECT 1',
+      timeRange: { from: '2024-01-01T00:00:00.000Z', to: '2024-01-01T01:00:00.000Z' },
+      dateTimeType: 'DATETIME',
+    });
+  });
+
+  it('createQueryWithAdhoc defaults null adhoc filters to []', async () => {
+    respondWith({ sql: 'SELECT 1' });
+    await getClient().createQueryWithAdhoc({ query: 'SELECT 1' }, null as any);
+    expect(fetchMock.mock.calls[0][0].data).toEqual({ query: 'SELECT 1', adhocFilters: [] });
+  });
+
+  it('processQueryBatch defaults filters and extract properties to []', async () => {
+    respondWith({ sql: 'SELECT 1', keys: [], properties: {} });
+    const client = getClient();
+    await client.processQueryBatch({ query: 'SELECT 1' }, null as any, null as any);
+    await client.processQueryBatch({ query: 'SELECT 1' }, null as any);
+    for (const call of fetchMock.mock.calls) {
+      expect(call[0]).toMatchObject({
+        url: '/api/datasources/uid/UID/resources/processQueryBatch',
+        data: { query: 'SELECT 1', adhocFilters: [], extractProperties: [] },
+      });
+    }
+  });
+
+  it('getMultipleAstProperties sends the property list', async () => {
+    respondWith({ properties: { select: [], where: [] } });
+    await expect(getClient().getMultipleAstProperties('SELECT 1', ['select', 'where'])).resolves.toEqual({
+      properties: { select: [], where: [] },
+    });
+    expect(fetchMock.mock.calls[0][0].data).toEqual({ query: 'SELECT 1', properties: ['select', 'where'] });
+  });
+});

--- a/src/datasource/response_parser.more.test.ts
+++ b/src/datasource/response_parser.more.test.ts
@@ -1,0 +1,89 @@
+import ResponseParser from './response_parser';
+
+const parser = new ResponseParser();
+
+describe('ResponseParser.parse', () => {
+  it('returns [] for null or empty results', () => {
+    expect(parser.parse('q', null)).toEqual([]);
+    expect(parser.parse('q', undefined)).toEqual([]);
+    expect(parser.parse('q', { data: [] })).toEqual([]);
+  });
+
+  it('reads meta and data from nested results.data', () => {
+    const results = { data: { meta: [{ name: 'x' }], data: [{ x: 'v' }] } };
+    expect(parser.parse('q', results)).toEqual([{ text: 'v' }]);
+  });
+
+  it('wraps non-object rows as text', () => {
+    const results = { meta: [{ name: 'x' }], data: ['a', 42] };
+    expect(parser.parse('q', results)).toEqual([{ text: 'a' }, { text: 42 }]);
+  });
+
+  it('maps single-key rows to text', () => {
+    const results = { meta: [{ name: 'x' }], data: [{ x: 'v1' }, { x: 'v2' }] };
+    expect(parser.parse('q', results)).toEqual([{ text: 'v1' }, { text: 'v2' }]);
+  });
+
+  it('maps __text/__value pairs to text and value', () => {
+    const results = {
+      meta: [{ name: '__text' }, { name: '__value' }],
+      data: [{ __text: 'Label', __value: 'id-1' }],
+    };
+    expect(parser.parse('q', results)).toEqual([{ text: 'Label', value: 'id-1' }]);
+  });
+
+  it('passes multi-key rows through when no __text/__value pair exists', () => {
+    const results = {
+      meta: [{ name: 'a' }, { name: 'b' }],
+      data: [{ a: 1, b: 2 }],
+    };
+    expect(parser.parse('q', results)).toEqual([{ a: 1, b: 2 }]);
+  });
+});
+
+describe('ResponseParser.findColIndex', () => {
+  it('finds a column or returns -1', () => {
+    expect(ResponseParser.findColIndex(['a', 'b'], 'b')).toBe(1);
+    expect(ResponseParser.findColIndex(['a'], 'z')).toBe(-1);
+  });
+});
+
+describe('transformAnnotationResponse', () => {
+  const options = { annotation: { name: 'anno' } };
+
+  it('throws without a time column', () => {
+    const data = { meta: [{ name: 'text' }], data: [] };
+    expect(() => parser.transformAnnotationResponse(options, data)).toThrow(
+      'Missing mandatory time column in annotation query.'
+    );
+  });
+
+  it('builds region events with split tags and custom type', () => {
+    const data = {
+      meta: [{ name: 'time' }, { name: 'time_end' }, { name: 'type' }],
+      data: [{ time: 1000.7, time_end: 2000, type: 'deploy', title: 'T', text: 'txt', tags: ' a , b ' }],
+    };
+    expect(parser.transformAnnotationResponse(options, data)).toEqual([
+      {
+        annotation: options.annotation,
+        time: 1000,
+        timeEnd: 2000,
+        isRegion: true,
+        title: 'T',
+        type: 'deploy',
+        text: 'txt',
+        tags: ['a', 'b'],
+      },
+    ]);
+  });
+
+  it('defaults type and tags for plain events', () => {
+    const data = {
+      meta: [{ name: 'time' }],
+      data: [{ time: 1000, title: 'T', text: 'txt' }],
+    };
+    expect(parser.transformAnnotationResponse(options, data)).toEqual([
+      expect.objectContaining({ time: 1000, timeEnd: 0, isRegion: false, type: 'annotation', tags: [] }),
+    ]);
+  });
+});

--- a/src/datasource/sql-series/sql_series.units.test.ts
+++ b/src/datasource/sql-series/sql_series.units.test.ts
@@ -1,0 +1,91 @@
+import SqlSeries, {
+  _toFieldType,
+  convertTimezonedDateToUTC,
+  convertTimezonedDateToUnixTimestamp,
+} from './sql_series';
+import { FieldType } from '@grafana/data';
+
+describe('convertTimezonedDate helpers', () => {
+  it('converts a zoned datetime to UTC ISO', () => {
+    const iso = convertTimezonedDateToUTC('2024-01-15 12:00:00', 'Europe/Berlin');
+    expect(new Date(iso!).getTime()).toBe(Date.UTC(2024, 0, 15, 11));
+  });
+
+  it('converts a zoned datetime to a unix timestamp', () => {
+    expect(convertTimezonedDateToUnixTimestamp('2024-01-15 12:00:00', 'UTC')).toBe(Date.UTC(2024, 0, 15, 12));
+  });
+
+  it.each([['convertTimezonedDateToUTC', convertTimezonedDateToUTC], ['convertTimezonedDateToUnixTimestamp', convertTimezonedDateToUnixTimestamp]])(
+    '%s throws on invalid input',
+    (_name, fn: any) => {
+      expect(() => fn('garbage', 'UTC')).toThrow('Invalid datetime format');
+    }
+  );
+});
+
+describe('_toFieldType', () => {
+  it('strips Nullable wrappers', () => {
+    expect(_toFieldType('Nullable(Int32)')).toBe(FieldType.number);
+  });
+
+  it('treats a UInt column at index 0 as time', () => {
+    expect(_toFieldType('UInt32', 0)).toBe(FieldType.time);
+    expect(_toFieldType('UInt32', 1)).toBe(FieldType.number);
+  });
+
+  it('extracts the timezone from DateTime types', () => {
+    expect(_toFieldType("DateTime64(3, 'UTC')")).toEqual({ fieldType: FieldType.time, timezone: 'UTC' });
+    expect(_toFieldType('Date')).toBe(FieldType.time);
+  });
+
+  it('maps IPv types to other and everything else to string', () => {
+    expect(_toFieldType('IPv4')).toBe(FieldType.other);
+    expect(_toFieldType('LowCardinality(String)')).toBe(FieldType.string);
+  });
+});
+
+describe('SqlSeries wrappers', () => {
+  it('toAnnotation delegates with meta-driven time parsing', () => {
+    const series = new SqlSeries({});
+    const [frame] = series.toAnnotation(
+      [{ time: '1704067200000', time_end: '0', title: 'T', text: 'txt', tags: 'a,b' }],
+      [{ name: 'time', type: 'UInt64' }]
+    );
+    expect(frame.fields.find((f: any) => f.name === 'time').values).toEqual([1704067200000]);
+    expect(frame.fields.find((f: any) => f.name === 'tags').values).toEqual([['a', 'b']]);
+  });
+
+  it('toFlamegraph delegates and prepends the synthetic root', () => {
+    const series = new SqlSeries({
+      series: [
+        { label: 'root', level: 1, value: '10', self: 2 },
+        { label: 'child', level: 2, value: '5', self: 5 },
+      ],
+    });
+    const [frame] = series.toFlamegraph();
+    expect(frame.fields.find((f: any) => f.name === 'label').values).toEqual(['all', 'root', 'child']);
+    expect(frame.fields.find((f: any) => f.name === 'value').values).toEqual([10, 10, 5]);
+  });
+
+  it('toTraces delegates and stringifies span ids', () => {
+    const series = new SqlSeries({
+      series: [
+        {
+          traceID: 1,
+          spanID: 11189782786942380395,
+          parentSpanID: null,
+          serviceName: 'svc',
+          startTime: '1704067200000',
+          duration: 5,
+          operationName: 'op',
+          tags: { k: 'v' },
+          serviceTags: {},
+        },
+      ],
+      meta: [{ name: 'startTime', type: 'UInt64' }],
+    });
+    const [frame] = series.toTraces();
+    expect(frame.fields.find((f: any) => f.name === 'traceID').values).toEqual(['1']);
+    expect(frame.fields.find((f: any) => f.name === 'tags').values).toEqual([[{ key: 'k', value: 'v' }]]);
+  });
+});

--- a/src/datasource/sql-series/toLogs.types.test.ts
+++ b/src/datasource/sql-series/toLogs.types.test.ts
@@ -1,0 +1,56 @@
+import { toLogs } from './toLogs';
+
+describe('toLogs type handling', () => {
+  it('returns [] when no String column exists', () => {
+    const result = toLogs({
+      series: [{ ts: '2024-01-15 12:00:00', num: 1 }],
+      meta: [
+        { name: 'ts', type: 'DateTime' },
+        { name: 'num', type: 'UInt64' },
+      ],
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('converts DateTime with timezone to UTC for the timestamp field', () => {
+    const [frame] = toLogs({
+      series: [{ ts: '2024-01-15 12:00:00', content: 'msg' }],
+      meta: [
+        { name: 'ts', type: "DateTime('Europe/Berlin')" },
+        { name: 'content', type: 'String' },
+      ],
+      refId: 'A',
+    });
+    const timestamp = frame.fields.find((f: any) => f.name === 'timestamp')!;
+    expect(new Date(timestamp.values[0]).getTime()).toBe(Date.UTC(2024, 0, 15, 11));
+  });
+
+  it('exposes numeric columns as labels and keeps IPv columns out of them', () => {
+    const [frame] = toLogs({
+      series: [{ content: 'msg', code: 500, ip: '1.2.3.4' }],
+      meta: [
+        { name: 'content', type: 'String' },
+        { name: 'code', type: 'Int32' },
+        { name: 'ip', type: 'IPv4' },
+      ],
+      refId: 'A',
+    });
+    const labels = frame.fields.find((f: any) => f.name === 'labels')!;
+    expect(labels.values[0]).toEqual({ code: 500 });
+  });
+
+  it('maps level to the severity field and keeps id', () => {
+    const [frame] = toLogs({
+      series: [{ content: 'msg', level: 'error', id: 'row-1' }],
+      meta: [
+        { name: 'content', type: 'String' },
+        { name: 'level', type: 'String' },
+        { name: 'id', type: 'String' },
+      ],
+      refId: 'A',
+    });
+    expect(frame.fields.find((f: any) => f.name === 'severity')!.values[0]).toBe('error');
+    expect(frame.fields.find((f: any) => f.name === 'id')!.values[0]).toBe('row-1');
+    expect(frame.fields.find((f: any) => f.name === 'body')!.values[0]).toBe('msg');
+  });
+});

--- a/src/datasource/sql-series/toTimeSeries.gaps.test.ts
+++ b/src/datasource/sql-series/toTimeSeries.gaps.test.ts
@@ -1,0 +1,145 @@
+import { toTimeSeries } from './toTimeSeries';
+
+const meta = [
+  { name: 't', type: 'UInt64' },
+  { name: 'val', type: 'Float64' },
+];
+
+const makeSelf = (overrides: any = {}) => ({
+  refId: 'A',
+  keys: [],
+  meta,
+  series: [],
+  tillNow: false,
+  from: 0,
+  to: 0,
+  ...overrides,
+});
+
+// 10 points at 1s spacing, seconds 1..10
+const rampSeries = (values: number[]) => values.map((v, i) => ({ t: (i + 1) * 1000, val: v }));
+
+describe('toTimeSeries extrapolation', () => {
+  it('returns [] for an empty series', () => {
+    expect(toTimeSeries(true, false, makeSelf())).toEqual([]);
+  });
+
+  it('extrapolates a zero first value near the left range border', () => {
+    const self = makeSelf({
+      series: rampSeries([0, 10, 20, 30, 40, 50, 60, 70, 80, 90]),
+      tillNow: true,
+      from: 0.9,
+      to: 12,
+    });
+    const [frame] = toTimeSeries(true, false, self);
+    // dp0 = dp1 * (1 + ((dp1-dp2)/dp1)*0.1) = 10 * 0.9
+    expect(frame.fields[1].values[0]).toBeCloseTo(9);
+  });
+
+  it('extrapolates the last value near the right range border', () => {
+    const self = makeSelf({
+      series: rampSeries([0, 10, 20, 30, 40, 50, 60, 70, 80, 90]),
+      tillNow: true,
+      from: 0,
+      to: 10.5,
+    });
+    const [frame] = toTimeSeries(true, false, self);
+    expect(frame.fields[1].values[9]).toBeCloseTo(80 * (1 + ((80 - 70) / 80) * 0.1));
+  });
+
+  it('keeps a zero first value when the following value is also zero (NaN guard)', () => {
+    const self = makeSelf({
+      series: rampSeries([0, 0, 20, 30, 40, 50, 60, 70, 80, 90]),
+      tillNow: true,
+      from: 0.9,
+      to: 12,
+    });
+    const [frame] = toTimeSeries(true, false, self);
+    expect(frame.fields[1].values[0]).toBe(0);
+  });
+
+  it('skips extrapolation for fewer than 10 points', () => {
+    const self = makeSelf({ series: rampSeries([0, 10, 20]), tillNow: true, from: 0.9, to: 3.1 });
+    const [frame] = toTimeSeries(true, false, self);
+    expect(frame.fields[1].values[0]).toBe(0);
+  });
+
+  it('skips extrapolation when not tillNow and the first value is non-zero', () => {
+    const self = makeSelf({
+      series: rampSeries([5, 10, 20, 30, 40, 50, 60, 70, 80, 90]),
+      tillNow: false,
+      from: 0.9,
+      to: 10.5,
+    });
+    const [frame] = toTimeSeries(true, false, self);
+    expect(frame.fields[1].values[0]).toBe(5);
+    expect(frame.fields[1].values[9]).toBe(90);
+  });
+});
+
+describe('toTimeSeries timezone handling', () => {
+  it('converts DateTime with explicit timezone to UTC', () => {
+    const self = makeSelf({
+      meta: [{ name: 't', type: "DateTime('Europe/Berlin')" }, { name: 'val', type: 'UInt64' }],
+      series: [{ t: '2024-01-15 12:00:00', val: 1 }],
+    });
+    const [frame] = toTimeSeries(false, false, self);
+    expect(new Date(frame.fields[0].values[0]).getTime()).toBe(Date.UTC(2024, 0, 15, 11));
+  });
+
+  it('treats plain DateTime strings as UTC', () => {
+    const self = makeSelf({
+      meta: [{ name: 't', type: 'DateTime' }, { name: 'val', type: 'UInt64' }],
+      series: [{ t: '2024-01-15 12:00:00', val: 1 }],
+    });
+    const [frame] = toTimeSeries(false, false, self);
+    expect(new Date(frame.fields[0].values[0]).getTime()).toBe(Date.UTC(2024, 0, 15, 12));
+  });
+});
+
+describe('toTimeSeries value and key shapes', () => {
+  it('stringifies object GROUP BY keys into the series name', () => {
+    const self = makeSelf({
+      keys: ['tag'],
+      meta: [meta[0], { name: 'tag', type: 'Object' }, meta[1]],
+      series: [{ t: 1000, tag: { a: 1 }, val: 5 }],
+    });
+    const [frame] = toTimeSeries(false, false, self);
+    expect(frame.fields[1].name).toBe('{"a":1}');
+    expect(frame.refId).toBe('A - {"a":1}');
+  });
+
+  it('stringifies object metric values', () => {
+    const self = makeSelf({ series: [{ t: 1000, val: { x: 1 } }] });
+    const [frame] = toTimeSeries(false, false, self);
+    expect(frame.fields[1].values).toEqual(['{"x":1}']);
+  });
+
+  it('backfills and appends nulls for sparse series when nullifySparse is set', () => {
+    const self = makeSelf({
+      keys: ['host'],
+      meta: [meta[0], { name: 'host', type: 'String' }, meta[1]],
+      series: [
+        { t: 1000, host: 'a', val: 1 },
+        { t: 2000, host: 'b', val: 5 },
+        { t: 3000, host: 'a', val: 2 },
+        { t: 4000, host: 'b', val: 6 },
+      ],
+    });
+    const frames = toTimeSeries(false, true, self);
+    const byName = Object.fromEntries(frames.map((f: any) => [f.fields[1].name, f]));
+    expect(byName['a'].fields[0].values).toEqual([1000, 2000, 3000]);
+    expect(byName['a'].fields[1].values).toEqual([1, null, 2]);
+    expect(byName['b'].fields[0].values).toEqual([1000, 2000, 3000, 4000]);
+    expect(byName['b'].fields[1].values).toEqual([null, 5, null, 6]);
+  });
+
+  it('expands groupArray values into multiple series', () => {
+    const self = makeSelf({
+      meta: [meta[0], { name: 'arr', type: 'Array(Tuple(String, UInt64))' }],
+      series: [{ t: 1000, arr: [['x', 1], ['y', 2]] }],
+    });
+    const frames = toTimeSeries(false, false, self);
+    expect(frames.map((f: any) => f.fields[1].name).sort()).toEqual(['x', 'y']);
+  });
+});

--- a/src/spec/testUtils/index.ts
+++ b/src/spec/testUtils/index.ts
@@ -1,0 +1,59 @@
+import { fireEvent, screen } from '@testing-library/react';
+
+// jsdom shims required by @grafana/ui (matchMedia is shimmed globally in .config/jest-setup.js)
+if (!(window as any).ResizeObserver) {
+  (window as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+if (!(window as any).IntersectionObserver) {
+  (window as any).IntersectionObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+      return [];
+    }
+  };
+}
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+export const makeOptions = (jsonData: any = {}, overrides: any = {}) => ({
+  id: 1,
+  uid: 'uid-1',
+  orgId: 1,
+  name: 'clickhouse-test',
+  type: 'vertamedia-clickhouse-datasource',
+  typeName: 'ClickHouse',
+  typeLogoUrl: '',
+  access: 'proxy',
+  url: '',
+  user: '',
+  database: '',
+  basicAuth: '',
+  basicAuthUser: '',
+  isDefault: false,
+  readOnly: false,
+  withCredentials: false,
+  version: 2,
+  secureJsonFields: {},
+  secureJsonData: {},
+  jsonData: { dataSourceUrl: '', ...jsonData },
+  ...overrides,
+});
+
+export const makeQuery = (overrides: any = {}) => ({
+  refId: 'A',
+  query: '',
+  ...overrides,
+});
+
+// Grafana Select: open menu via keyboard, then click the option by its text
+export const selectOption = async (input: HTMLElement, optionText: string) => {
+  fireEvent.keyDown(input, { key: 'ArrowDown' });
+  fireEvent.click(await screen.findByText(optionText));
+};

--- a/src/spec/useAutocompletionData.jest.ts
+++ b/src/spec/useAutocompletionData.jest.ts
@@ -1,5 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { useAutocompleteData } from '../views/QueryEditor/hooks/useAutocompletionData';
+import { IndexedDBManager } from '../utils/indexedDBManager';
 
 jest.mock('../utils/indexedDBManager', () => ({
   IndexedDBManager: {
@@ -83,5 +84,47 @@ describe('useAutocompleteData permission error detection (issue #816)', () => {
 
     await waitFor(() => expect(result.current.data).toEqual({}));
     expect(result.current.hasPermissionError).toBe(false);
+  });
+});
+
+describe('useAutocompleteData cache and cleanup paths', () => {
+  const mockedIDB = IndexedDBManager as jest.Mocked<typeof IndexedDBManager>;
+
+  it('uses a cached permission error without querying', async () => {
+    // first getItem call is the permission-error key
+    mockedIDB.getItem.mockResolvedValueOnce(true);
+    const datasource = { uid: 'uid-cached-error', metricFindQuery: jest.fn() };
+
+    const { result } = renderHook(() => useAutocompleteData(datasource));
+
+    await waitFor(() => expect(result.current.hasPermissionError).toBe(true));
+    expect(result.current.data).toEqual({});
+    expect(datasource.metricFindQuery).not.toHaveBeenCalled();
+  });
+
+  it('returns cached autocomplete data without querying', async () => {
+    mockedIDB.getItem.mockResolvedValueOnce(null).mockResolvedValueOnce({ identifier: ['count'] });
+    const datasource = { uid: 'uid-cached-data', metricFindQuery: jest.fn() };
+
+    const { result } = renderHook(() => useAutocompleteData(datasource));
+
+    await waitFor(() => expect(result.current.data).toEqual({ identifier: ['count'] }));
+    expect(result.current.hasPermissionError).toBe(false);
+    expect(datasource.metricFindQuery).not.toHaveBeenCalled();
+  });
+
+  it('logs a failed cache cleanup and still fetches', async () => {
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockedIDB.cleanupExpiredByPrefix.mockRejectedValueOnce(new Error('cleanup failed'));
+    const datasource = {
+      uid: 'uid-cleanup',
+      metricFindQuery: jest.fn().mockResolvedValue([{ completion: 'count', color: 'identifier' }]),
+    };
+
+    const { result } = renderHook(() => useAutocompleteData(datasource));
+
+    await waitFor(() => expect(result.current.data).toEqual({ identifier: ['count'] }));
+    expect(error).toHaveBeenCalledWith('Failed to cleanup expired autocomplete data:', expect.any(Error));
+    error.mockRestore();
   });
 });

--- a/src/utils/clickhouseErrorHandling.test.ts
+++ b/src/utils/clickhouseErrorHandling.test.ts
@@ -1,0 +1,27 @@
+import { isPermissionError, getPermissionErrorMessage, PermissionErrorContext } from './clickhouseErrorHandling';
+
+describe('isPermissionError residual branches', () => {
+  it('returns false for null/undefined errors', () => {
+    expect(isPermissionError(null)).toBe(false);
+    expect(isPermissionError(undefined)).toBe(false);
+  });
+
+  it('classifies a top-level permission status code', () => {
+    expect(isPermissionError({ status: 497 })).toBe(true);
+  });
+
+  it('classifies a nested data.status code and falls back to error.message', () => {
+    expect(isPermissionError({ data: { status: 291 } })).toBe(true);
+    expect(isPermissionError({ message: 'Not enough privileges' })).toBe(true);
+    expect(isPermissionError({ message: 'Code: 516.' })).toBe(true);
+    expect(isPermissionError({ status: 500, data: {} })).toBe(false);
+  });
+});
+
+describe('getPermissionErrorMessage', () => {
+  it('omits the datasource suffix when no datasourceId is given', () => {
+    const msg = getPermissionErrorMessage(PermissionErrorContext.TABLES);
+    expect(msg).toBe('ClickHouse system table access denied for TABLES query - returning empty result');
+    expect(msg).not.toContain('datasource:');
+  });
+});

--- a/src/utils/indexedDBManager.test.ts
+++ b/src/utils/indexedDBManager.test.ts
@@ -1,0 +1,254 @@
+import { IDBFactory, IDBKeyRange } from 'fake-indexeddb';
+import { IndexedDBManager } from './indexedDBManager';
+
+// jsdom in this Jest setup has no structuredClone, which fake-indexeddb requires.
+// JSON cloning is sufficient for the plain values these tests store.
+(globalThis as any).structuredClone ??= (v: any) => (v === undefined ? v : JSON.parse(JSON.stringify(v)));
+
+const HOUR = 60 * 60 * 1000;
+
+// Write a record whose timestamp/expiry are computed from a spied Date.now (real timers:
+// fake timers would stall the IDB microtask machinery).
+const setItemAt = async (ts: number, key: string, data: any, ttlMinutes?: number) => {
+  const spy = jest.spyOn(Date, 'now').mockReturnValue(ts);
+  try {
+    await IndexedDBManager.setItem(key, data, ttlMinutes);
+  } finally {
+    spy.mockRestore();
+  }
+};
+
+const waitUntil = async (cond: () => Promise<boolean>) => {
+  for (let i = 0; i < 50; i++) {
+    if (await cond()) {
+      return;
+    }
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  throw new Error('condition not reached');
+};
+
+beforeEach(() => {
+  (IndexedDBManager as any).dbPromise = null;
+  (globalThis as any).indexedDB = new IDBFactory();
+  (globalThis as any).IDBKeyRange = IDBKeyRange;
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('getItem / setItem', () => {
+  it('round-trips data without TTL (expiry 0 is always returned)', async () => {
+    await IndexedDBManager.setItem('altinity_k', { a: 1 });
+    expect(await IndexedDBManager.getItem('altinity_k')).toEqual({ a: 1 });
+  });
+
+  it('round-trips data with a live TTL', async () => {
+    await IndexedDBManager.setItem('altinity_k', 'v', 10);
+    expect(await IndexedDBManager.getItem('altinity_k')).toBe('v');
+  });
+
+  it('returns null for a missing key', async () => {
+    expect(await IndexedDBManager.getItem('nope')).toBeNull();
+  });
+
+  it('returns null for an expired record and deletes it', async () => {
+    await setItemAt(Date.now() - HOUR, 'altinity_old', 'v', 1);
+    expect(await IndexedDBManager.getItem('altinity_old')).toBeNull();
+    // deletion is fire-and-forget inside getItem
+    await waitUntil(async () => (await IndexedDBManager.getStorageStats()).totalKeys === 0);
+  });
+});
+
+describe('prefix classification (via getStorageStats)', () => {
+  it('classifies altinity_, dataStorage_ and other keys', async () => {
+    await IndexedDBManager.setItem('altinity_x', 1);
+    await IndexedDBManager.setItem('dataStorage_x', 2);
+    await IndexedDBManager.setItem('other_x', 3);
+    const stats = await IndexedDBManager.getStorageStats();
+    expect(stats).toMatchObject({ totalKeys: 3, altinityKeys: 1, dataStorageKeys: 1 });
+  });
+});
+
+describe('removeItem', () => {
+  it('removes an existing key and tolerates a non-existent one', async () => {
+    await IndexedDBManager.setItem('altinity_k', 'v');
+    await IndexedDBManager.removeItem('altinity_k');
+    expect(await IndexedDBManager.getItem('altinity_k')).toBeNull();
+    await expect(IndexedDBManager.removeItem('missing')).resolves.toBeUndefined();
+  });
+});
+
+describe('cleanupExpiredByPrefix', () => {
+  it('removes only expired records under the given prefix', async () => {
+    const past = Date.now() - HOUR;
+    await setItemAt(past, 'altinity_expired', 'x', 1);
+    await IndexedDBManager.setItem('altinity_live', 'y', 10);
+    await setItemAt(past, 'dataStorage_expired', 'z', 1);
+
+    const stats = await IndexedDBManager.cleanupExpiredByPrefix('altinity_');
+    expect(stats).toEqual({ totalKeys: 2, expiredKeys: 1, removedKeys: 1, totalSize: expect.any(Number) });
+    expect(stats.totalSize).toBeGreaterThan(0);
+    // other prefix untouched
+    expect((await IndexedDBManager.getStorageStats()).totalKeys).toBe(2);
+  });
+
+  it('returns zeros on an empty store', async () => {
+    expect(await IndexedDBManager.cleanupExpiredByPrefix('altinity_')).toEqual({
+      totalKeys: 0,
+      expiredKeys: 0,
+      removedKeys: 0,
+      totalSize: 0,
+    });
+  });
+});
+
+describe('cleanupAllExpired', () => {
+  it('sums stats over both prefixes', async () => {
+    const past = Date.now() - HOUR;
+    await setItemAt(past, 'altinity_expired', 'x', 1);
+    await setItemAt(past, 'dataStorage_expired', 'y', 1);
+    await IndexedDBManager.setItem('altinity_live', 'z');
+
+    const stats = await IndexedDBManager.cleanupAllExpired();
+    expect(stats.totalKeys).toBe(3);
+    expect(stats.expiredKeys).toBe(2);
+    expect(stats.removedKeys).toBe(2);
+    expect((await IndexedDBManager.getStorageStats()).totalKeys).toBe(1);
+  });
+});
+
+describe('cleanupOrphanedDatasources', () => {
+  it('removes datasource keys whose uid is not active; permission_error keys never match an active uid', async () => {
+    await IndexedDBManager.setItem('altinity_autocomplete_uid1', 'a');
+    await IndexedDBManager.setItem('altinity_systemDatabases_uid2', 'b');
+    await IndexedDBManager.setItem('altinity_autocomplete_permission_error_uid1', 'c');
+    await IndexedDBManager.setItem('altinity_misc', 'd');
+
+    // The regex captures 'permission_error_uid1', which is never in the uid set,
+    // so permission-error caches are dropped even for active datasources.
+    const removed = await IndexedDBManager.cleanupOrphanedDatasources(['uid1']);
+    expect(removed).toBe(2);
+    expect(await IndexedDBManager.getItem('altinity_autocomplete_uid1')).toBe('a');
+    expect(await IndexedDBManager.getItem('altinity_systemDatabases_uid2')).toBeNull();
+    expect(await IndexedDBManager.getItem('altinity_autocomplete_permission_error_uid1')).toBeNull();
+    expect(await IndexedDBManager.getItem('altinity_misc')).toBe('d');
+  });
+});
+
+describe('limitQueryStatesPerDatasource', () => {
+  it('returns 0 when within the limit', async () => {
+    await IndexedDBManager.setItem('dataStorage_a_uid1_A', 1);
+    expect(await IndexedDBManager.limitQueryStatesPerDatasource('uid1', 3)).toBe(0);
+  });
+
+  it('removes the oldest records above the limit; other datasources not counted', async () => {
+    const t0 = Date.now() - 5000;
+    for (let i = 0; i < 5; i++) {
+      await setItemAt(t0 + i * 1000, `dataStorage_ds_uid1_${i}`, i);
+    }
+    await setItemAt(t0, 'dataStorage_ds_uid2_x', 'other');
+
+    expect(await IndexedDBManager.limitQueryStatesPerDatasource('uid1', 3)).toBe(2);
+    // oldest two of uid1 removed, uid2 untouched
+    expect(await IndexedDBManager.getItem('dataStorage_ds_uid1_0')).toBeNull();
+    expect(await IndexedDBManager.getItem('dataStorage_ds_uid1_1')).toBeNull();
+    expect(await IndexedDBManager.getItem('dataStorage_ds_uid1_2')).toBe(2);
+    expect(await IndexedDBManager.getItem('dataStorage_ds_uid2_x')).toBe('other');
+  });
+});
+
+describe('performEmergencyCleanup', () => {
+  it('removes the oldest 25% of prefixed records; unprefixed records survive', async () => {
+    const t0 = Date.now() - 5000;
+    await setItemAt(t0, 'altinity_oldest', 0);
+    await setItemAt(t0 + 1000, 'altinity_1', 1);
+    await setItemAt(t0 + 2000, 'dataStorage_2', 2);
+    await setItemAt(t0 + 3000, 'dataStorage_3', 3);
+    await setItemAt(t0, 'unprefixed', 'keep');
+
+    await IndexedDBManager.performEmergencyCleanup();
+    // floor(4 * 0.25) = 1 -> only the oldest prefixed record goes
+    expect(await IndexedDBManager.getItem('altinity_oldest')).toBeNull();
+    expect(await IndexedDBManager.getItem('altinity_1')).toBe(1);
+    expect(await IndexedDBManager.getItem('unprefixed')).toBe('keep');
+    expect((await IndexedDBManager.getStorageStats()).totalKeys).toBe(4);
+  });
+});
+
+describe('getStorageStats', () => {
+  it('estimates size as 2 * (key length + JSON length)', async () => {
+    const key = 'altinity_size';
+    const data = { v: 'abc' };
+    await IndexedDBManager.setItem(key, data);
+    const stats = await IndexedDBManager.getStorageStats();
+    expect(stats.estimatedSize).toBe(2 * (key.length + JSON.stringify(data).length));
+    expect(stats.estimatedSize).toBeGreaterThan(0);
+  });
+});
+
+describe('clearAllAltinityData', () => {
+  it('deletes prefixed records and keeps unprefixed ones', async () => {
+    await IndexedDBManager.setItem('altinity_a', 1);
+    await IndexedDBManager.setItem('dataStorage_b', 2);
+    await IndexedDBManager.setItem('other_c', 3);
+    await IndexedDBManager.clearAllAltinityData();
+    const stats = await IndexedDBManager.getStorageStats();
+    expect(stats).toMatchObject({ totalKeys: 1, altinityKeys: 0, dataStorageKeys: 0 });
+    expect(await IndexedDBManager.getItem('other_c')).toBe(3);
+  });
+});
+
+describe('error paths when the DB cannot be opened', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const failed = Promise.reject(new Error('db unavailable'));
+    failed.catch(() => {}); // avoid unhandled rejection
+    (IndexedDBManager as any).dbPromise = failed;
+  });
+
+  it('getItem resolves null', async () => {
+    expect(await IndexedDBManager.getItem('k')).toBeNull();
+  });
+
+  it('removeItem resolves silently', async () => {
+    await expect(IndexedDBManager.removeItem('k')).resolves.toBeUndefined();
+  });
+
+  it('cleanupExpiredByPrefix returns zero stats', async () => {
+    expect(await IndexedDBManager.cleanupExpiredByPrefix('altinity_')).toEqual({
+      totalKeys: 0,
+      expiredKeys: 0,
+      removedKeys: 0,
+      totalSize: 0,
+    });
+  });
+
+  it('cleanupOrphanedDatasources returns 0', async () => {
+    expect(await IndexedDBManager.cleanupOrphanedDatasources(['uid'])).toBe(0);
+  });
+
+  it('limitQueryStatesPerDatasource returns 0', async () => {
+    expect(await IndexedDBManager.limitQueryStatesPerDatasource('uid')).toBe(0);
+  });
+
+  it('getStorageStats returns zeros', async () => {
+    expect(await IndexedDBManager.getStorageStats()).toEqual({
+      totalKeys: 0,
+      altinityKeys: 0,
+      dataStorageKeys: 0,
+      estimatedSize: 0,
+    });
+  });
+
+  it('clearAllAltinityData resolves silently', async () => {
+    await expect(IndexedDBManager.clearAllAltinityData()).resolves.toBeUndefined();
+  });
+
+  it('setItem is the only method that rethrows', async () => {
+    // performEmergencyCleanup also swallows the failure internally
+    await expect(IndexedDBManager.setItem('k', 'v')).rejects.toThrow('db unavailable');
+    await expect(IndexedDBManager.performEmergencyCleanup()).resolves.toBeUndefined();
+  });
+});

--- a/src/views/ConfigEditor/ConfigEditor.test.tsx
+++ b/src/views/ConfigEditor/ConfigEditor.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 jest.mock('react-calendar', () => ({}));
 // Monaco cannot run under jsdom; replace CodeEditor with a plain textarea
 jest.mock('@grafana/ui', () => ({

--- a/src/views/ConfigEditor/ConfigEditor.test.tsx
+++ b/src/views/ConfigEditor/ConfigEditor.test.tsx
@@ -1,0 +1,88 @@
+jest.mock('react-calendar', () => ({}));
+// Monaco cannot run under jsdom; replace CodeEditor with a plain textarea
+jest.mock('@grafana/ui', () => ({
+  ...jest.requireActual('@grafana/ui'),
+  CodeEditor: ({ value, onChange }: any) => (
+    <textarea data-testid="code-editor" value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { makeOptions, selectOption } from 'spec/testUtils';
+import { ConfigEditor } from './ConfigEditor';
+
+const setup = (jsonData: any = {}, overrides: any = {}) => {
+  const onOptionsChange = jest.fn();
+  const options = makeOptions(jsonData, overrides);
+  const utils = render(<ConfigEditor options={options as any} onOptionsChange={onOptionsChange} />);
+  onOptionsChange.mockClear(); // drop the mount-time adHocValuesQuery sync call
+  return { onOptionsChange, options, ...utils };
+};
+
+const lastJsonData = (fn: jest.Mock) => fn.mock.calls[fn.mock.calls.length - 1][0].jsonData;
+
+describe('ConfigEditor', () => {
+  it('renders http settings and main sections', () => {
+    setup();
+    expect(screen.getByText('Use Yandex.Cloud authorization headers')).toBeInTheDocument();
+    expect(screen.getByText('Additional')).toBeInTheDocument();
+    expect(screen.queryByText('X-ClickHouse-User')).not.toBeInTheDocument();
+  });
+
+  it('syncs adHocValuesQuery into jsonData on mount', () => {
+    const onOptionsChange = jest.fn();
+    render(<ConfigEditor options={makeOptions() as any} onOptionsChange={onOptionsChange} />);
+    expect(lastJsonData(onOptionsChange).adHocValuesQuery).toContain('SELECT');
+  });
+
+  it('toggles yandex cloud authorization', () => {
+    const { onOptionsChange } = setup();
+    fireEvent.click(document.getElementById('useYandexCloudAuthorization')!);
+    expect(lastJsonData(onOptionsChange).useYandexCloudAuthorization).toBe(true);
+  });
+
+  it('shows and edits yandex auth fields when enabled', () => {
+    const { onOptionsChange } = setup({ useYandexCloudAuthorization: true });
+    fireEvent.change(document.getElementById('xHeaderUser')!, { target: { value: 'bob' } });
+    expect(lastJsonData(onOptionsChange).xHeaderUser).toBe('bob');
+
+    fireEvent.change(screen.getByPlaceholderText('DB user password'), { target: { value: 's3cret' } });
+    const call = onOptionsChange.mock.calls[onOptionsChange.mock.calls.length - 1][0];
+    expect(call.secureJsonData.xHeaderKey).toBe('s3cret');
+
+    fireEvent.click(document.getElementById('xClickHouseSSLCertificateAuth')!);
+    expect(lastJsonData(onOptionsChange).xClickHouseSSLCertificateAuth).toBe(true);
+  });
+
+  it('toggles additional switches', () => {
+    const { onOptionsChange } = setup();
+    fireEvent.click(document.getElementById('addCorsHeader')!);
+    expect(lastJsonData(onOptionsChange).addCorsHeader).toBe(true);
+    fireEvent.click(document.getElementById('usePOST')!);
+    expect(lastJsonData(onOptionsChange).usePOST).toBe(true);
+    fireEvent.click(document.getElementById('useCompressions')!);
+    expect(lastJsonData(onOptionsChange).useCompression).toBe(true);
+    fireEvent.click(document.getElementById('adhoc')!);
+    expect(lastJsonData(onOptionsChange).adHocHideTableNames).toBe(true);
+  });
+
+  it('edits default database', () => {
+    const { onOptionsChange } = setup();
+    fireEvent.change(screen.getByPlaceholderText('default'), { target: { value: 'mydb' } });
+    expect(lastJsonData(onOptionsChange).defaultDatabase).toBe('mydb');
+  });
+
+  it('selects compression type', async () => {
+    const { onOptionsChange } = setup({ useCompression: true });
+    const selects = screen.getAllByRole('combobox');
+    await selectOption(selects[selects.length - 1], 'gzip');
+    expect(lastJsonData(onOptionsChange).compressionType).toBe('gzip');
+  });
+
+  it('edits adhoc filter query through the code editor', () => {
+    const { onOptionsChange } = setup();
+    fireEvent.change(screen.getByTestId('code-editor'), { target: { value: 'SELECT 1' } });
+    expect(lastJsonData(onOptionsChange).adHocValuesQuery).toBe('SELECT 1');
+  });
+});

--- a/src/views/ConfigEditor/FormParts/DefaultValues/DefaultValues.test.tsx
+++ b/src/views/ConfigEditor/FormParts/DefaultValues/DefaultValues.test.tsx
@@ -1,0 +1,127 @@
+jest.mock('react-calendar', () => ({}));
+jest.mock('./DefaultValues.api');
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { selectOption } from 'spec/testUtils';
+import { DefaultValues } from './DefaultValues';
+import { getOptions, getSettings } from './DefaultValues.api';
+
+const mockGetSettings = getSettings as jest.Mock;
+const mockGetOptions = getOptions as jest.Mock;
+
+// dataSourceUrl '' keeps the fetch effect inert unless a test opts in
+const setup = (jsonData: any = {}, newOptions: any = {}) => {
+  const onSwitchToggle = jest.fn();
+  const onFieldChange = jest.fn();
+  render(
+    <DefaultValues
+      jsonData={{ dataSourceUrl: '', ...jsonData }}
+      newOptions={{ version: 2, uid: 'uid-1', ...newOptions }}
+      onSwitchToggle={onSwitchToggle}
+      onFieldChange={onFieldChange}
+    />
+  );
+  return { onSwitchToggle, onFieldChange };
+};
+
+const columns = (rows: Array<[string, string]>) => ({
+  data: rows.map(([name, type]) => ({ name, type, database: 'db', table: 't' })),
+});
+
+describe('DefaultValues', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders collapsed when useDefaultConfiguration is off', () => {
+    setup();
+    expect(screen.getByText('Use default values')).toBeInTheDocument();
+    expect(screen.queryByText('TimestampType')).not.toBeInTheDocument();
+  });
+
+  it('toggles useDefaultConfiguration', () => {
+    const { onSwitchToggle } = setup();
+    fireEvent.click(document.getElementById('useDefaultConfiguration')!);
+    expect(onSwitchToggle).toHaveBeenCalledWith('useDefaultConfiguration', true);
+  });
+
+  it('renders all sections when enabled', () => {
+    setup({ useDefaultConfiguration: true });
+    expect(screen.getByText('TimestampType')).toBeInTheDocument();
+    expect(screen.getByText('DateTime columns')).toBeInTheDocument();
+    expect(screen.getByText('Datetime Field')).toBeInTheDocument();
+    expect(screen.getByText('Logs settings')).toBeInTheDocument();
+    expect(screen.getByText('Macros settings')).toBeInTheDocument();
+  });
+
+  it('shows save-first alert for unsaved datasource (version 1)', () => {
+    setup({ useDefaultConfiguration: true }, { version: 1 });
+    expect(screen.getByText(/Please save data source before use default configurations/)).toBeInTheDocument();
+  });
+
+  it('changes timestamp type via select', async () => {
+    const { onFieldChange } = setup({ useDefaultConfiguration: true });
+    await selectOption(screen.getAllByRole('combobox')[0], 'DateTime64');
+    expect(onFieldChange).toHaveBeenCalledWith({ value: 'DATETIME64' }, 'defaultDateTimeType');
+  });
+
+  it('changes context window size via select', async () => {
+    const { onFieldChange } = setup({ useDefaultConfiguration: true });
+    const selects = screen.getAllByRole('combobox');
+    await selectOption(selects[selects.length - 1], '50 entries');
+    expect(onFieldChange).toHaveBeenCalledWith({ value: '50' }, 'contextWindowSize');
+  });
+
+  it('toggles macros switches', () => {
+    const { onSwitchToggle } = setup({ useDefaultConfiguration: true });
+    fireEvent.click(screen.getByTestId('use-window-func-for-macros'));
+    expect(onSwitchToggle).toHaveBeenCalledWith('useWindowFuncForMacros', false);
+    fireEvent.click(screen.getByTestId('nullify-sparse-switch'));
+    expect(onSwitchToggle).toHaveBeenCalledWith('nullifySparse', true);
+  });
+
+  it('loads column options grouped by normalized type', async () => {
+    mockGetSettings.mockResolvedValue({ datasources: { a: { uid: 'uid-1', basicAuth: 'Basic xyz' } } });
+    mockGetOptions.mockResolvedValue(
+      columns([
+        ['dt_col', 'DateTime'],
+        ['dt_tz_col', "DateTime('UTC')"],
+        ['dt64_col', 'DateTime64(3)'],
+        ['u32_col', 'UInt32'],
+        ['u64_col', 'UInt64'],
+        ['d_col', 'Date'],
+        ['f_col', 'LowCardinality(Float64)'],
+        ['dec_col', 'Nullable(Decimal(10,2))'],
+      ])
+    );
+    const { onFieldChange } = setup({ useDefaultConfiguration: true, dataSourceUrl: 'http://localhost:8123' });
+    expect(await screen.findByText('Datetime Field')).toBeInTheDocument();
+    expect(mockGetOptions).toHaveBeenCalled();
+
+    // DateTime select gets both plain and timezone-typed columns
+    const dtSelect = screen.getAllByRole('combobox')[1];
+    fireEvent.keyDown(dtSelect, { key: 'ArrowDown' });
+    expect(await screen.findByText('dt_col')).toBeInTheDocument();
+    expect(screen.getByText('dt_tz_col')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('dt_col'));
+    expect(onFieldChange).toHaveBeenCalledWith({ value: 'dt_col' }, 'defaultDateTime');
+
+    // Float select merges Float and Decimal columns
+    const floatSelect = screen.getAllByRole('combobox')[4];
+    fireEvent.keyDown(floatSelect, { key: 'ArrowDown' });
+    expect(await screen.findByText('f_col')).toBeInTheDocument();
+    expect(screen.getByText('dec_col')).toBeInTheDocument();
+  });
+
+  it('skips fetch when url is not http(s)', () => {
+    setup({ useDefaultConfiguration: true, dataSourceUrl: 'localhost:8123' });
+    expect(mockGetSettings).not.toHaveBeenCalled();
+  });
+
+  it('recovers when the options request fails', async () => {
+    mockGetSettings.mockResolvedValue({ datasources: { a: { uid: 'uid-1' } } });
+    mockGetOptions.mockRejectedValue(new Error('boom'));
+    setup({ useDefaultConfiguration: true, dataSourceUrl: 'http://localhost:8123' });
+    expect(await screen.findByText('Datetime Field')).toBeInTheDocument();
+    expect(mockGetOptions).toHaveBeenCalled();
+  });
+});

--- a/src/views/ConfigEditor/FormParts/DefaultValues/DefaultValues.test.tsx
+++ b/src/views/ConfigEditor/FormParts/DefaultValues/DefaultValues.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 jest.mock('react-calendar', () => ({}));
 jest.mock('./DefaultValues.api');
 

--- a/src/views/QueryEditor/QueryEditor.test.tsx
+++ b/src/views/QueryEditor/QueryEditor.test.tsx
@@ -1,0 +1,113 @@
+jest.mock('react-calendar', () => ({}));
+jest.mock('./components/QueryTextEditor/SQLCodeEditor', () => ({
+  SQLCodeEditor: ({ onSqlChange }: any) => (
+    <button data-testid="sql-editor" onClick={() => onSqlChange('SELECT 2')} />
+  ),
+}));
+jest.mock('./components/QueryBuilder/hooks/useConnectionData');
+jest.mock('./hooks/useFormattedData');
+jest.mock('./hooks/useAutocompletionData');
+jest.mock('./hooks/useQueryState');
+jest.mock('./helpers/getAdHocFilters');
+jest.mock('./helpers/detectVariableMacroIntersections');
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import 'spec/testUtils';
+import { QueryEditor, QueryEditorVariable } from './QueryEditor';
+import { useConnectionData } from './components/QueryBuilder/hooks/useConnectionData';
+import { useFormattedData } from './hooks/useFormattedData';
+import { useAutocompleteData } from './hooks/useAutocompletionData';
+import { getAdhocFilters } from './helpers/getAdHocFilters';
+import {
+  detectVariableMacroIntersections,
+  createVariableMacroConflictWarning,
+} from './helpers/detectVariableMacroIntersections';
+
+const setters = Array.from({ length: 5 }, () => jest.fn());
+// selections must be non-empty strings: UniversalSelectField loops forever on empty values
+(useConnectionData as jest.Mock).mockReturnValue([[], [], [], [], 'ts', 'd', ...setters, 't', 'db', 'DATETIME']);
+(useAutocompleteData as jest.Mock).mockReturnValue({ data: null, hasPermissionError: false });
+(getAdhocFilters as jest.Mock).mockReturnValue([]);
+
+const mockFormatted = useFormattedData as jest.Mock;
+const mockConflicts = detectVariableMacroIntersections as jest.Mock;
+const mockWarning = createVariableMacroConflictWarning as jest.Mock;
+
+const setup = (queryOver: any = {}, Component: any = QueryEditor) => {
+  const onChange = jest.fn();
+  const onRunQuery = jest.fn();
+  render(
+    <Component
+      datasource={{} as any}
+      query={{ refId: 'A', query: 'SELECT 1', ...queryOver } as any}
+      onChange={onChange}
+      onRunQuery={onRunQuery}
+      app="panel-editor"
+    />
+  );
+  return { onChange, onRunQuery };
+};
+
+describe('QueryEditor', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFormatted.mockReturnValue(['SELECT 1', null]);
+    mockConflicts.mockReturnValue([]);
+    mockWarning.mockReturnValue('');
+  });
+
+  it('renders builder mode by default', () => {
+    setup();
+    expect(screen.getByLabelText('Query Settings')).toBeChecked();
+    expect(screen.queryByTestId('sql-editor')).not.toBeInTheDocument();
+  });
+
+  it('renders SQL editor mode with Run Query and wires onSqlChange', () => {
+    const { onChange, onRunQuery } = setup({ editorMode: 'sql' });
+    fireEvent.click(screen.getByTestId('sql-editor'));
+    expect(onChange.mock.calls.some(([q]) => q.query === 'SELECT 2')).toBe(true);
+    fireEvent.click(screen.getByText('Run Query'));
+    expect(onRunQuery).toHaveBeenCalled();
+  });
+
+  it('opens SQL mode when query has database and table', () => {
+    setup({ database: 'db', table: 't' });
+    expect(screen.getByTestId('sql-editor')).toBeInTheDocument();
+  });
+
+  it('shows formatting error alert', () => {
+    mockFormatted.mockReturnValue(['', 'Bad SQL syntax']);
+    setup({ editorMode: 'sql' });
+    expect(screen.getByText('Bad SQL syntax')).toBeInTheDocument();
+  });
+
+  it('shows variable/macro conflict warning', () => {
+    mockConflicts.mockReturnValue(['timeFilter']);
+    mockWarning.mockReturnValue('Variable conflicts with macro: timeFilter');
+    setup();
+    expect(screen.getByText('Variable/Macro Name Conflict Warning')).toBeInTheDocument();
+    expect(screen.getByText('Variable conflicts with macro: timeFilter')).toBeInTheDocument();
+  });
+
+  it('propagates formattedQuery when formatter output differs', () => {
+    mockFormatted.mockReturnValue(['SELECT 1 FORMATTED', null]);
+    const { onChange } = setup({ editorMode: 'sql' });
+    expect(onChange.mock.calls.some(([q]) => q.formattedQuery === 'SELECT 1 FORMATTED')).toBe(true);
+  });
+});
+
+describe('QueryEditorVariable', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFormatted.mockReturnValue(['SELECT 1', null]);
+    mockConflicts.mockReturnValue([]);
+    mockWarning.mockReturnValue('');
+  });
+
+  it('renders header tabs for variable editor', () => {
+    setup({}, QueryEditorVariable);
+    expect(screen.getByLabelText('Query Settings')).toBeInTheDocument();
+    expect(screen.getByLabelText('SQL Editor')).toBeInTheDocument();
+  });
+});

--- a/src/views/QueryEditor/QueryEditor.test.tsx
+++ b/src/views/QueryEditor/QueryEditor.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 jest.mock('react-calendar', () => ({}));
 jest.mock('./components/QueryTextEditor/SQLCodeEditor', () => ({
   SQLCodeEditor: ({ onSqlChange }: any) => (

--- a/src/views/QueryEditor/components/QueryBuilder/QueryBuilder.test.tsx
+++ b/src/views/QueryEditor/components/QueryBuilder/QueryBuilder.test.tsx
@@ -1,8 +1,9 @@
+import '@testing-library/jest-dom';
 jest.mock('react-calendar', () => ({}));
 jest.mock('./hooks/useConnectionData');
 
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { selectOption } from 'spec/testUtils';
 import { QueryBuilder } from './QueryBuilder';
 import { useConnectionData } from './hooks/useConnectionData';

--- a/src/views/QueryEditor/components/QueryBuilder/QueryBuilder.test.tsx
+++ b/src/views/QueryEditor/components/QueryBuilder/QueryBuilder.test.tsx
@@ -1,0 +1,90 @@
+jest.mock('react-calendar', () => ({}));
+jest.mock('./hooks/useConnectionData');
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { selectOption } from 'spec/testUtils';
+import { QueryBuilder } from './QueryBuilder';
+import { useConnectionData } from './hooks/useConnectionData';
+
+const setters = {
+  setSelectedDatabase: jest.fn(),
+  setSelectedTable: jest.fn(),
+  setSelectedColumnTimestampType: jest.fn(),
+  setSelectedColumnDateType: jest.fn(),
+  setSelectedDateTimeType: jest.fn(),
+};
+
+(useConnectionData as jest.Mock).mockReturnValue([
+  [{ label: 'db1', value: 'db1' }, { label: 'db2', value: 'db2' }], // databases
+  [{ label: 't1', value: 't1' }], // tables
+  [{ label: 'd_col', value: 'd_col' }], // dateColumns
+  [{ label: 'ts_col', value: 'ts_col' }, { label: 'ts2_col', value: 'ts2_col' }], // timestampColumns
+  'ts_col',
+  'd_col',
+  setters.setSelectedDatabase,
+  setters.setSelectedTable,
+  setters.setSelectedColumnTimestampType,
+  setters.setSelectedColumnDateType,
+  setters.setSelectedDateTimeType,
+  't1',
+  'db1',
+  'DATETIME',
+]);
+
+const query = {
+  refId: 'A',
+  database: 'db1',
+  table: 't1',
+  dateTimeColDataType: 'ts_col',
+  dateColDataType: 'd_col',
+  dateTimeType: 'DATETIME',
+};
+
+const setup = () => {
+  const onChange = jest.fn();
+  render(<QueryBuilder query={query} onChange={onChange} datasource={{}} />);
+  return onChange;
+};
+
+describe('QueryBuilder', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('syncs selection state from query on mount', () => {
+    setup();
+    expect(setters.setSelectedDatabase).toHaveBeenCalledWith('db1');
+    expect(setters.setSelectedTable).toHaveBeenCalledWith('t1');
+    expect(setters.setSelectedColumnTimestampType).toHaveBeenCalledWith('ts_col');
+    expect(setters.setSelectedColumnDateType).toHaveBeenCalledWith('d_col');
+    expect(setters.setSelectedDateTimeType).toHaveBeenCalledWith('DATETIME');
+  });
+
+  it('renders current selections', () => {
+    setup();
+    expect(screen.getByText('db1')).toBeInTheDocument();
+    expect(screen.getByText('t1')).toBeInTheDocument();
+    expect(screen.getByText('ts_col')).toBeInTheDocument();
+    expect(screen.getByText('d_col')).toBeInTheDocument();
+  });
+
+  it('propagates database change', async () => {
+    const onChange = setup();
+    await selectOption(screen.getAllByRole('combobox')[0], 'db2');
+    expect(setters.setSelectedDatabase).toHaveBeenCalledWith('db2');
+    expect(onChange).toHaveBeenCalledWith({ ...query, database: 'db2' });
+  });
+
+  it('propagates timestamp type change', async () => {
+    const onChange = setup();
+    await selectOption(screen.getAllByRole('combobox')[2], 'DateTime64');
+    expect(setters.setSelectedDateTimeType).toHaveBeenCalledWith('DATETIME64');
+    expect(onChange).toHaveBeenCalledWith({ ...query, dateTimeType: 'DATETIME64' });
+  });
+
+  it('propagates timestamp column change', async () => {
+    const onChange = setup();
+    await selectOption(screen.getAllByRole('combobox')[3], 'ts2_col');
+    expect(setters.setSelectedColumnTimestampType).toHaveBeenCalledWith('ts2_col');
+    expect(onChange).toHaveBeenCalledWith({ ...query, dateTimeColDataType: 'ts2_col' });
+  });
+});

--- a/src/views/QueryEditor/components/QueryBuilder/components/UniversalSelectComponent.test.tsx
+++ b/src/views/QueryEditor/components/QueryBuilder/components/UniversalSelectComponent.test.tsx
@@ -1,0 +1,52 @@
+jest.mock('react-calendar', () => ({}));
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { selectOption } from 'spec/testUtils';
+import { UniversalSelectField } from './UniversalSelectComponent';
+
+const options = [
+  { label: 'alpha', value: 'alpha' },
+  { label: 'beta', value: 'beta' },
+];
+
+describe('UniversalSelectField', () => {
+  it('renders placeholder and selected value', () => {
+    render(<UniversalSelectField value="alpha" onChange={jest.fn()} options={options} placeholder="pick" />);
+    expect(screen.getByText('alpha')).toBeInTheDocument();
+  });
+
+  it('injects unknown value as a custom option', () => {
+    render(<UniversalSelectField value="custom_col" onChange={jest.fn()} options={options} />);
+    expect(screen.getByText('custom_col')).toBeInTheDocument();
+  });
+
+  // value must stay defined: the component's sync effect loops forever on undefined values
+  it('fires onChange with option value', async () => {
+    const onChange = jest.fn();
+    render(<UniversalSelectField value="alpha" onChange={onChange} options={options} placeholder="pick" />);
+    await selectOption(screen.getByRole('combobox'), 'beta');
+    expect(onChange).toHaveBeenCalledWith({ value: 'beta' });
+  });
+
+  it('creates custom option from typed value', async () => {
+    const onChange = jest.fn();
+    render(<UniversalSelectField value="alpha" onChange={onChange} options={options} placeholder="pick" />);
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'my_col ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onChange).toHaveBeenCalledWith({ value: 'my_col' });
+  });
+
+  it('deduplicates options against injected custom ones', () => {
+    render(
+      <UniversalSelectField
+        value="alpha"
+        onChange={jest.fn()}
+        options={[...options, { label: 'alpha', value: 'alpha' }]}
+      />
+    );
+    fireEvent.keyDown(screen.getByRole('combobox'), { key: 'ArrowDown' });
+    expect(screen.getAllByText('alpha').length).toBeLessThanOrEqual(2); // selected value + single menu entry
+  });
+});

--- a/src/views/QueryEditor/components/QueryBuilder/components/UniversalSelectComponent.test.tsx
+++ b/src/views/QueryEditor/components/QueryBuilder/components/UniversalSelectComponent.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 jest.mock('react-calendar', () => ({}));
 
 import React from 'react';

--- a/src/views/QueryEditor/components/QueryBuilder/hooks/useConnectionData.test.ts
+++ b/src/views/QueryEditor/components/QueryBuilder/hooks/useConnectionData.test.ts
@@ -1,0 +1,128 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useConnectionData } from './useConnectionData';
+import { TimestampFormat } from '../../../../../types/types';
+
+const DATABASES_QUERY = 'SELECT name FROM system.databases ORDER BY name';
+
+const makeDatasource = (rows: any[] = [{ text: 'db1' }, { text: 'db2' }]) => ({
+  metricFindQuery: jest.fn().mockResolvedValue(rows),
+});
+
+const calls = (ds: any): string[] => ds.metricFindQuery.mock.calls.map((c: any[]) => c[0]);
+
+describe('useConnectionData', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('fetches databases on mount and maps {text} to {label, value}', async () => {
+    const ds = makeDatasource();
+    const { result } = renderHook(() => useConnectionData({}, ds));
+    await waitFor(() =>
+      expect(result.current[0]).toEqual([
+        { label: 'db1', value: 'db1' },
+        { label: 'db2', value: 'db2' },
+      ])
+    );
+    expect(ds.metricFindQuery).toHaveBeenCalledWith(DATABASES_QUERY);
+  });
+
+  it('queries tables only after a database is selected', async () => {
+    const ds = makeDatasource([{ text: 't1' }]);
+    const { result } = renderHook(() => useConnectionData({}, ds));
+    await waitFor(() => expect(ds.metricFindQuery).toHaveBeenCalled());
+    expect(calls(ds).some((q) => q.includes('system.tables'))).toBe(false);
+
+    act(() => result.current[6]('mydb'));
+    await waitFor(() => expect(calls(ds).some((q) => q.includes("system.tables WHERE database = 'mydb'"))).toBe(true));
+    await waitFor(() => expect(result.current[1]).toEqual([{ label: 't1', value: 't1' }]));
+  });
+
+  it('fetches date columns when database and table are set', async () => {
+    const ds = makeDatasource([{ text: 'd' }]);
+    renderHook(() => useConnectionData({ database: 'db', table: 'tbl' }, ds));
+    await waitFor(() => {
+      const dateQuery = calls(ds).find((q) => q.includes("'Date','Date32'"));
+      expect(dateQuery).toContain("database = 'db'");
+      expect(dateQuery).toContain("table = 'tbl'");
+      expect(dateQuery).toContain("UNION ALL SELECT ' ' AS name");
+    });
+  });
+
+  it.each([
+    [TimestampFormat.DateTime, ["substring(type,1,8) = 'DateTime'", "substring(type,1,10) != 'DateTime64'"]],
+    [TimestampFormat.DateTime64, ["substring(type,1,10) = 'DateTime64'"]],
+    [TimestampFormat.TimeStamp, ["type = 'UInt32'"]],
+    [TimestampFormat.TimeStamp64_3, ["type LIKE '%UInt64%'"]],
+    [TimestampFormat.TimeStamp64_6, ["type LIKE '%UInt64%'"]],
+    [TimestampFormat.TimeStamp64_9, ["type LIKE '%UInt64%'"]],
+    [TimestampFormat.Float, ["type LIKE '%Float%'", "type LIKE '%Decimal%'"]],
+  ])('builds the timestamp column query for %s', async (type, fragments) => {
+    const ds = makeDatasource([{ text: 'c' }]);
+    const { result } = renderHook(() => useConnectionData({ database: 'db', table: 'tbl' }, ds));
+    act(() => result.current[10](type));
+    await waitFor(() => {
+      const q = calls(ds).find((c) => fragments.every((f: string) => c.includes(f)));
+      expect(q).toBeDefined();
+      expect(q).toContain("database = 'db'");
+    });
+    await waitFor(() => expect(result.current[3]).toEqual([{ label: 'c', value: 'c' }]));
+  });
+
+  it('returns [] for an unknown timestamp type without issuing a query', async () => {
+    const ds = makeDatasource([{ text: 'c' }]);
+    const { result } = renderHook(() => useConnectionData({ database: 'db', table: 'tbl' }, ds));
+    act(() => result.current[10]('BOGUS'));
+    // date-columns query still runs; the unknown type must not
+    await waitFor(() => expect(calls(ds).some((q) => q.includes("'Date','Date32'"))).toBe(true));
+    expect(ds.metricFindQuery).not.toHaveBeenCalledWith(undefined);
+    expect(result.current[3]).toEqual([]);
+  });
+
+  it('handles permission errors on DATABASES with an empty list and console.info', async () => {
+    const info = jest.spyOn(console, 'info').mockImplementation(() => {});
+    const ds = { metricFindQuery: jest.fn().mockRejectedValue({ status: 497 }) };
+    const { result } = renderHook(() => useConnectionData({}, ds));
+    await waitFor(() => expect(info).toHaveBeenCalledWith(expect.stringContaining('DATABASES')));
+    expect(result.current[0]).toEqual([]);
+    info.mockRestore();
+  });
+
+  it('handles permission errors on TABLES with an empty list and console.info', async () => {
+    const info = jest.spyOn(console, 'info').mockImplementation(() => {});
+    const ds = {
+      metricFindQuery: jest.fn((q: string) =>
+        q.includes('system.tables') ? Promise.reject({ status: 497 }) : Promise.resolve([{ text: 'db1' }])
+      ),
+    };
+    const { result } = renderHook(() => useConnectionData({ database: 'db' }, ds));
+    await waitFor(() => expect(info).toHaveBeenCalledWith(expect.stringContaining('TABLES')));
+    expect(result.current[1]).toEqual([]);
+    info.mockRestore();
+  });
+
+  it('handles generic errors with an empty list and console.error', async () => {
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const ds = { metricFindQuery: jest.fn().mockRejectedValue(new Error('boom')) };
+    const { result } = renderHook(() => useConnectionData({}, ds));
+    await waitFor(() => expect(error).toHaveBeenCalledWith('Failed to fetch databases:', expect.any(Error)));
+    expect(result.current[0]).toEqual([]);
+    error.mockRestore();
+  });
+
+  it('seeds selection state from the query', async () => {
+    const ds = makeDatasource();
+    const query = {
+      database: 'db',
+      table: 'tbl',
+      dateTimeColDataType: 'ts_col',
+      dateColDataType: 'date_col',
+      dateTimeType: TimestampFormat.DateTime64,
+    };
+    const { result } = renderHook(() => useConnectionData(query, ds));
+    expect(result.current[4]).toBe('ts_col');
+    expect(result.current[5]).toBe('date_col');
+    expect(result.current[11]).toBe('tbl');
+    expect(result.current[12]).toBe('db');
+    expect(result.current[13]).toBe(TimestampFormat.DateTime64);
+    await waitFor(() => expect(ds.metricFindQuery).toHaveBeenCalled());
+  });
+});

--- a/src/views/QueryEditor/components/QueryHeader/QueryHeader.test.tsx
+++ b/src/views/QueryEditor/components/QueryHeader/QueryHeader.test.tsx
@@ -1,0 +1,83 @@
+jest.mock('react-calendar', () => ({}));
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import 'spec/testUtils';
+import { QueryHeader } from './QueryHeader';
+import { EditorMode } from '../../../../types/types';
+
+const setup = (over: any = {}) => {
+  const props = {
+    editorMode: EditorMode.SQL,
+    setEditorMode: jest.fn(),
+    isAnnotationView: false,
+    onTriggerQuery: jest.fn(),
+    datasource: {} as any,
+    query: { refId: 'A', dateTimeType: 'DATETIME' } as any,
+    onChange: jest.fn(),
+    hasAutocompleteError: false,
+    ...over,
+  };
+  render(<QueryHeader {...props} />);
+  return props;
+};
+
+// datasource defaults that differ from the query by dateTimeType only
+const datasourceWithDefaults = {
+  defaultValues: {
+    defaultDateTimeType: 'DATETIME64',
+    dateTime: {},
+  },
+} as any;
+
+describe('QueryHeader', () => {
+  it('runs query from SQL mode', () => {
+    const { onTriggerQuery } = setup();
+    fireEvent.click(screen.getByText('Run Query'));
+    expect(onTriggerQuery).toHaveBeenCalled();
+  });
+
+  it('hides Run Query in annotation view', () => {
+    setup({ isAnnotationView: true });
+    expect(screen.queryByText('Run Query')).not.toBeInTheDocument();
+  });
+
+  it('shows autocomplete error badge only in SQL mode', () => {
+    setup({ hasAutocompleteError: true });
+    expect(screen.getByText(/Autocomplete unavailable/)).toBeInTheDocument();
+  });
+
+  it('switches editor mode via tabs', () => {
+    const { setEditorMode, onChange, query } = setup();
+    fireEvent.click(screen.getByLabelText('Query Settings'));
+    expect(setEditorMode).toHaveBeenCalledWith(EditorMode.Builder);
+    expect(onChange).toHaveBeenCalledWith({ ...query, editorMode: EditorMode.Builder });
+  });
+
+  it('navigates from builder to SQL mode', () => {
+    const { setEditorMode } = setup({ editorMode: EditorMode.Builder });
+    fireEvent.click(screen.getByText('Go to Query'));
+    expect(setEditorMode).toHaveBeenCalledWith(EditorMode.SQL);
+  });
+
+  it('offers override only when query differs from datasource defaults', () => {
+    setup({ editorMode: EditorMode.Builder });
+    expect(screen.queryByText('Override settings')).not.toBeInTheDocument();
+  });
+
+  it('resets differing fields through the confirmation modal', () => {
+    const { onChange, query } = setup({ editorMode: EditorMode.Builder, datasource: datasourceWithDefaults });
+    fireEvent.click(screen.getByText('Override settings'));
+    expect(screen.getByText(/Configuration will be reset/)).toBeInTheDocument();
+    expect(screen.getByText('DATETIME → DATETIME64')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Confirm'));
+    expect(onChange).toHaveBeenCalledWith({ ...query, dateTimeType: 'DATETIME64' });
+  });
+
+  it('cancel closes the modal without changes', () => {
+    const { onChange } = setup({ editorMode: EditorMode.Builder, datasource: datasourceWithDefaults });
+    fireEvent.click(screen.getByText('Override settings'));
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/views/QueryEditor/components/QueryHeader/QueryHeader.test.tsx
+++ b/src/views/QueryEditor/components/QueryHeader/QueryHeader.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 jest.mock('react-calendar', () => ({}));
 
 import React from 'react';

--- a/src/views/QueryEditor/components/QueryHeader/helpers/findDifferences.test.ts
+++ b/src/views/QueryEditor/components/QueryHeader/helpers/findDifferences.test.ts
@@ -1,0 +1,109 @@
+import { findDifferences } from './findDifferences';
+import { TimestampFormat } from '../../../../../types/types';
+
+const ds = (defaultValues: any) => ({ defaultValues } as any);
+// keep boolean fields aligned with the query fixtures so only the branch under test differs
+const base = (dv: any = {}) => ({ dateTime: {}, useWindowFuncForMacros: true, nullifySparse: false, ...dv });
+
+describe('findDifferences', () => {
+  it('returns [] without defaultValues', () => {
+    expect(findDifferences({} as any, ds(undefined))).toEqual([]);
+  });
+
+  it('returns [] for a fully matching query', () => {
+    const defaults = base({
+      defaultDateTimeType: TimestampFormat.DateTime,
+      dateTime: { defaultDateTime: 'ts' },
+      contextWindowSize: '10',
+      useWindowFuncForMacros: true,
+      nullifySparse: false,
+    });
+    const query = {
+      dateTimeType: TimestampFormat.DateTime,
+      dateTimeColDataType: 'ts',
+      contextWindowSize: '10',
+      useWindowFuncForMacros: true,
+      nullifySparse: false,
+    } as any;
+    expect(findDifferences(query, ds(defaults))).toEqual([]);
+  });
+
+  it('dateTimeType mismatch: trims original, EMPTY for undefined and whitespace-only', () => {
+    const defaults = base({ defaultDateTimeType: TimestampFormat.DateTime });
+    const q = (v: any) => ({ dateTimeType: v, useWindowFuncForMacros: true, nullifySparse: false } as any);
+    expect(findDifferences(q('  DATETIME64  '), ds(defaults))).toEqual([
+      {
+        key: 'Timestamp type Column',
+        original: 'DATETIME64',
+        updated: TimestampFormat.DateTime,
+        fieldName: 'dateTimeType',
+      },
+    ]);
+    expect(findDifferences(q(undefined), ds(defaults))[0].original).toBe('EMPTY');
+    expect(findDifferences(q('  '), ds(defaults))[0].original).toBe('EMPTY');
+  });
+
+  it.each([
+    ['TIMESTAMP', 'defaultUint32', TimestampFormat.TimeStamp],
+    ['DATETIME64', 'defaultDateTime64', TimestampFormat.DateTime64],
+    ['DATETIME', 'defaultDateTime', TimestampFormat.DateTime],
+  ])('type-gated %s column diff via %s, suppressed when default is falsy', (_label, field, type) => {
+    const q = { dateTimeType: type, dateTimeColDataType: 'other', useWindowFuncForMacros: true, nullifySparse: false } as any;
+    const diffs = findDifferences(q, ds(base({ defaultDateTimeType: type, dateTime: { [field]: 'col' } })));
+    expect(diffs).toEqual([
+      { key: 'Timestamp Column', original: 'other', updated: 'col', fieldName: 'dateTimeColDataType' },
+    ]);
+    // falsy default suppresses the diff
+    expect(findDifferences(q, ds(base({ defaultDateTimeType: type, dateTime: { [field]: '' } })))).toEqual([]);
+  });
+
+  it('reports defaultDateDate32 mismatch', () => {
+    const q = { dateColDataType: 'd', useWindowFuncForMacros: true, nullifySparse: false } as any;
+    const diffs = findDifferences(q, ds(base({ dateTime: { defaultDateDate32: 'date32' } })));
+    expect(diffs).toEqual([{ key: 'Date column', original: 'd', updated: 'date32', fieldName: 'dateColDataType' }]);
+  });
+
+  it('reports contextWindowSize mismatch', () => {
+    const q = { contextWindowSize: '10', useWindowFuncForMacros: true, nullifySparse: false } as any;
+    const diffs = findDifferences(q, ds(base({ contextWindowSize: '20' })));
+    expect(diffs).toEqual([
+      { key: 'Logs context window size', original: '10', updated: '20', fieldName: 'contextWindowSize' },
+    ]);
+  });
+
+  it('useWindowFuncForMacros: undefined query value stringifies to "true"', () => {
+    const diffs = findDifferences({ nullifySparse: false } as any, ds(base({ useWindowFuncForMacros: true, nullifySparse: false })));
+    expect(diffs).toEqual([
+      { key: 'Use window functions for macros', original: 'true', updated: 'true', fieldName: 'useWindowFuncForMacros' },
+    ]);
+    const explicit = findDifferences(
+      { useWindowFuncForMacros: false, nullifySparse: false } as any,
+      ds(base({ useWindowFuncForMacros: true, nullifySparse: false }))
+    );
+    expect(explicit[0]).toMatchObject({ original: 'false', updated: 'true' });
+  });
+
+  it('nullifySparse: undefined query value stringifies to "false"', () => {
+    const diffs = findDifferences({ useWindowFuncForMacros: true } as any, ds(base({ useWindowFuncForMacros: true, nullifySparse: true })));
+    expect(diffs).toEqual([
+      { key: 'Nullify sparse categories', original: 'false', updated: 'true', fieldName: 'nullifySparse' },
+    ]);
+  });
+
+  it('dateTimeType mismatch does not short-circuit the column diff (both reported)', () => {
+    const defaults = base({
+      defaultDateTimeType: TimestampFormat.DateTime,
+      dateTime: { defaultDateTime: 'col' },
+      useWindowFuncForMacros: true,
+      nullifySparse: false,
+    });
+    const q = {
+      dateTimeType: TimestampFormat.DateTime64,
+      dateTimeColDataType: 'other',
+      useWindowFuncForMacros: true,
+      nullifySparse: false,
+    } as any;
+    const diffs = findDifferences(q, ds(defaults));
+    expect(diffs.map((d) => d.fieldName)).toEqual(['dateTimeType', 'dateTimeColDataType']);
+  });
+});

--- a/src/views/QueryEditor/components/QueryTextEditor/FormattedSQL.test.tsx
+++ b/src/views/QueryEditor/components/QueryTextEditor/FormattedSQL.test.tsx
@@ -1,0 +1,38 @@
+jest.mock('react-calendar', () => ({}));
+
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import 'spec/testUtils';
+import { FormattedSQL } from './FormattedSQL';
+
+const sql = 'SELECT *\nFROM table';
+
+describe('FormattedSQL', () => {
+  it('renders nothing when hidden', () => {
+    const { container } = render(<FormattedSQL sql={sql} showFormattedSQL={false} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the sql text when shown', () => {
+    render(<FormattedSQL sql={sql} showFormattedSQL={true} />);
+    expect(screen.getByText('Reformatted Query')).toBeInTheDocument();
+    expect(screen.getByText(/SELECT \*/)).toBeInTheDocument();
+  });
+
+  it('copies sql to clipboard and shows transient message', async () => {
+    jest.useFakeTimers();
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<FormattedSQL sql={sql} showFormattedSQL={true} />);
+    fireEvent.click(screen.getByLabelText('copy-formatted-data-to-clipboard'));
+    // flush the clipboard promise
+    await act(async () => {});
+    expect(writeText).toHaveBeenCalledWith(sql);
+    expect(screen.getByText('Copied!')).toBeInTheDocument();
+
+    act(() => jest.advanceTimersByTime(1500));
+    expect(screen.queryByText('Copied!')).not.toBeInTheDocument();
+    jest.useRealTimers();
+  });
+});

--- a/src/views/QueryEditor/components/QueryTextEditor/FormattedSQL.test.tsx
+++ b/src/views/QueryEditor/components/QueryTextEditor/FormattedSQL.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 jest.mock('react-calendar', () => ({}));
 
 import React from 'react';

--- a/src/views/QueryEditor/components/QueryTextEditor/QueryTextEditor.test.tsx
+++ b/src/views/QueryEditor/components/QueryTextEditor/QueryTextEditor.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 jest.mock('react-calendar', () => ({}));
 // Monaco-based editor cannot run under jsdom
 jest.mock('./SQLCodeEditor', () => ({

--- a/src/views/QueryEditor/components/QueryTextEditor/QueryTextEditor.test.tsx
+++ b/src/views/QueryEditor/components/QueryTextEditor/QueryTextEditor.test.tsx
@@ -1,0 +1,83 @@
+jest.mock('react-calendar', () => ({}));
+// Monaco-based editor cannot run under jsdom
+jest.mock('./SQLCodeEditor', () => ({
+  SQLCodeEditor: () => <div data-testid="sql-editor" />,
+}));
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { makeQuery } from 'spec/testUtils';
+import { QueryTextEditor } from './QueryTextEditor';
+
+const setup = (queryOver: any = {}, propsOver: any = {}) => {
+  const onFieldChange = jest.fn();
+  render(
+    <QueryTextEditor
+      query={makeQuery({ query: 'SELECT 1', format: 'time_series', ...queryOver }) as any}
+      onSqlChange={jest.fn()}
+      onFieldChange={onFieldChange}
+      formattedData="SELECT 1"
+      onRunQuery={jest.fn()}
+      datasource={{} as any}
+      isAnnotationView={false}
+      adhocFilters={[]}
+      areAdHocFiltersAvailable={true}
+      autocompleteData={null}
+      {...propsOver}
+    />
+  );
+  return onFieldChange;
+};
+
+describe('QueryTextEditor', () => {
+  it('renders editor with toggles, inputs and format select', () => {
+    setup();
+    expect(screen.getByTestId('sql-editor')).toBeInTheDocument();
+    expect(screen.getByTestId('extrapolate-switch')).toBeInTheDocument();
+    expect(screen.getByTestId('interval-input')).toBeInTheDocument();
+    expect(screen.getByTestId('round-input')).toBeInTheDocument();
+    expect(screen.getByText('Format As')).toBeInTheDocument();
+    expect(screen.queryByText('Poll interval')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('context-window-size-select')).not.toBeInTheDocument();
+  });
+
+  it('fires toggle and input handlers with fieldName payloads', () => {
+    const onFieldChange = setup({ extrapolate: true });
+    fireEvent.click(screen.getByTestId('extrapolate-switch'));
+    expect(onFieldChange).toHaveBeenCalledWith({ fieldName: 'extrapolate', value: false });
+    fireEvent.click(screen.getByTestId('streaming-switch'));
+    expect(onFieldChange).toHaveBeenCalledWith({ fieldName: 'streaming', value: true });
+    fireEvent.change(screen.getByTestId('interval-input'), { target: { value: '30s' } });
+    expect(onFieldChange).toHaveBeenCalledWith({ fieldName: 'interval', value: '30s' });
+    fireEvent.change(screen.getByTestId('round-input'), { target: { value: '1m' } });
+    expect(onFieldChange).toHaveBeenCalledWith({ fieldName: 'round', value: '1m' });
+  });
+
+  it('shows streaming controls only when streaming, lookback only in delta mode', () => {
+    setup({ streaming: true });
+    expect(screen.getByText('Poll interval')).toBeInTheDocument();
+    expect(screen.getByText('Streaming mode')).toBeInTheDocument();
+    expect(screen.getByText('Lookback points')).toBeInTheDocument();
+  });
+
+  it('hides lookback in full refresh mode', () => {
+    setup({ streaming: true, streamingMode: 'full' });
+    expect(screen.queryByText('Lookback points')).not.toBeInTheDocument();
+  });
+
+  it('shows context window select for logs format', () => {
+    setup({ format: 'logs' });
+    expect(screen.getByTestId('context-window-size-select')).toBeInTheDocument();
+  });
+
+  it('hides format select in annotation view', () => {
+    setup({}, { isAnnotationView: true });
+    expect(screen.queryByText('Format As')).not.toBeInTheDocument();
+  });
+
+  it('renders formatted SQL and macros help on demand', () => {
+    setup({ showFormattedSQL: true, showHelp: true });
+    expect(screen.getByText('Reformatted Query')).toBeInTheDocument();
+    expect(screen.getByText('Macros')).toBeInTheDocument();
+  });
+});

--- a/src/views/QueryEditor/components/QueryTextEditor/components/AdhocFilterTags/AdhocFilterTags.test.tsx
+++ b/src/views/QueryEditor/components/QueryTextEditor/components/AdhocFilterTags/AdhocFilterTags.test.tsx
@@ -1,0 +1,43 @@
+jest.mock('react-calendar', () => ({}));
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import 'spec/testUtils';
+import { AdhocFilterTags } from './AdhocFilterTags';
+
+const filters = [
+  { key: 'host', operator: '=', value: 'web1' },
+  { key: 'region', operator: '!=', value: 'us' },
+];
+
+describe('AdhocFilterTags', () => {
+  it('renders nothing when adhoc filters are natively available', () => {
+    const { container } = render(
+      <AdhocFilterTags adhocFilters={filters} areAdHocFiltersAvailable={true} onFieldChange={jest.fn()} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when there are no filters', () => {
+    const { container } = render(
+      <AdhocFilterTags adhocFilters={[]} areAdHocFiltersAvailable={false} onFieldChange={jest.fn()} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders one tag per filter', () => {
+    render(<AdhocFilterTags adhocFilters={filters} areAdHocFiltersAvailable={false} onFieldChange={jest.fn()} />);
+    expect(screen.getByText('host = web1')).toBeInTheDocument();
+    expect(screen.getByText('region != us')).toBeInTheDocument();
+  });
+
+  it('parses remaining tags back into filters on removal', () => {
+    const onFieldChange = jest.fn();
+    render(<AdhocFilterTags adhocFilters={filters} areAdHocFiltersAvailable={false} onFieldChange={onFieldChange} />);
+    fireEvent.click(screen.getByRole('button', { name: /host = web1/ }));
+    expect(onFieldChange).toHaveBeenCalledWith({
+      fieldName: 'adHocFilters',
+      value: [{ key: 'region', operator: '!=', value: 'us' }],
+    });
+  });
+});

--- a/src/views/QueryEditor/components/QueryTextEditor/components/AdhocFilterTags/AdhocFilterTags.test.tsx
+++ b/src/views/QueryEditor/components/QueryTextEditor/components/AdhocFilterTags/AdhocFilterTags.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 jest.mock('react-calendar', () => ({}));
 
 import React from 'react';

--- a/src/views/QueryEditor/components/QueryTextEditor/components/Inputs/StreamingIntervalInput.test.tsx
+++ b/src/views/QueryEditor/components/QueryTextEditor/components/Inputs/StreamingIntervalInput.test.tsx
@@ -1,0 +1,28 @@
+jest.mock('react-calendar', () => ({}));
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { selectOption, makeQuery } from 'spec/testUtils';
+import { StreamingIntervalInput } from './StreamingIntervalInput';
+
+describe('StreamingIntervalInput', () => {
+  it('renders default interval of 5s', () => {
+    render(<StreamingIntervalInput query={makeQuery() as any} handleStreamingIntervalChange={jest.fn()} />);
+    expect(screen.getByText('Poll interval')).toBeInTheDocument();
+    expect(screen.getByText('5s')).toBeInTheDocument();
+  });
+
+  it('renders explicit interval', () => {
+    render(
+      <StreamingIntervalInput query={makeQuery({ streamingInterval: 60000 }) as any} handleStreamingIntervalChange={jest.fn()} />
+    );
+    expect(screen.getByText('1m')).toBeInTheDocument();
+  });
+
+  it('fires handler with selected interval', async () => {
+    const handler = jest.fn();
+    render(<StreamingIntervalInput query={makeQuery() as any} handleStreamingIntervalChange={handler} />);
+    await selectOption(screen.getByRole('combobox'), '30s');
+    expect(handler.mock.calls[0][0].value).toBe(30000);
+  });
+});

--- a/src/views/QueryEditor/components/QueryTextEditor/components/Inputs/StreamingIntervalInput.test.tsx
+++ b/src/views/QueryEditor/components/QueryTextEditor/components/Inputs/StreamingIntervalInput.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 jest.mock('react-calendar', () => ({}));
 
 import React from 'react';

--- a/src/views/QueryEditor/components/QueryTextEditor/components/Selects/StreamingLookbackSelect.test.tsx
+++ b/src/views/QueryEditor/components/QueryTextEditor/components/Selects/StreamingLookbackSelect.test.tsx
@@ -1,0 +1,26 @@
+jest.mock('react-calendar', () => ({}));
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { selectOption, makeQuery } from 'spec/testUtils';
+import { StreamingLookbackSelect } from './StreamingLookbackSelect';
+
+describe('StreamingLookbackSelect', () => {
+  it('renders default lookback of 1', () => {
+    render(<StreamingLookbackSelect query={makeQuery() as any} onChange={jest.fn()} />);
+    expect(screen.getByText('Lookback points')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  it('renders explicit value including 0', () => {
+    render(<StreamingLookbackSelect query={makeQuery({ streamingLookback: 0 }) as any} onChange={jest.fn()} />);
+    expect(screen.getByText('0')).toBeInTheDocument();
+  });
+
+  it('fires onChange with selected lookback', async () => {
+    const onChange = jest.fn();
+    render(<StreamingLookbackSelect query={makeQuery() as any} onChange={onChange} />);
+    await selectOption(screen.getByRole('combobox'), '5');
+    expect(onChange.mock.calls[0][0].value).toBe(5);
+  });
+});

--- a/src/views/QueryEditor/components/QueryTextEditor/components/Selects/StreamingLookbackSelect.test.tsx
+++ b/src/views/QueryEditor/components/QueryTextEditor/components/Selects/StreamingLookbackSelect.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 jest.mock('react-calendar', () => ({}));
 
 import React from 'react';

--- a/src/views/QueryEditor/components/QueryTextEditor/components/Selects/StreamingModeSelect.test.tsx
+++ b/src/views/QueryEditor/components/QueryTextEditor/components/Selects/StreamingModeSelect.test.tsx
@@ -1,0 +1,40 @@
+// react-calendar is ESM-only and not in the scaffolded transform list; @grafana/ui barrel imports it
+jest.mock('react-calendar', () => ({}));
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { selectOption, makeQuery } from 'spec/testUtils';
+import { StreamingModeSelect } from './StreamingModeSelect';
+
+const warning = /Delta mode requires \$timeFilter/;
+
+describe('StreamingModeSelect', () => {
+  it('renders current mode and no warning for empty query', () => {
+    render(<StreamingModeSelect query={makeQuery() as any} onChange={jest.fn()} />);
+    expect(screen.getByText('Delta')).toBeInTheDocument();
+    expect(screen.queryByText(warning)).not.toBeInTheDocument();
+  });
+
+  it('warns when delta mode query lacks time macros', () => {
+    render(<StreamingModeSelect query={makeQuery({ query: 'SELECT 1' }) as any} onChange={jest.fn()} />);
+    expect(screen.getByText(warning)).toBeInTheDocument();
+  });
+
+  it('does not warn when $timeFilter present or mode is full', () => {
+    const { rerender } = render(
+      <StreamingModeSelect query={makeQuery({ query: 'SELECT 1 WHERE $timeFilter' }) as any} onChange={jest.fn()} />
+    );
+    expect(screen.queryByText(warning)).not.toBeInTheDocument();
+    rerender(
+      <StreamingModeSelect query={makeQuery({ query: 'SELECT 1', streamingMode: 'full' }) as any} onChange={jest.fn()} />
+    );
+    expect(screen.queryByText(warning)).not.toBeInTheDocument();
+  });
+
+  it('fires onChange with selected mode', async () => {
+    const onChange = jest.fn();
+    render(<StreamingModeSelect query={makeQuery() as any} onChange={onChange} />);
+    await selectOption(screen.getByRole('combobox'), 'Full refresh');
+    expect(onChange.mock.calls[0][0].value).toBe('full');
+  });
+});

--- a/src/views/QueryEditor/components/QueryTextEditor/components/Selects/StreamingModeSelect.test.tsx
+++ b/src/views/QueryEditor/components/QueryTextEditor/components/Selects/StreamingModeSelect.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 // react-calendar is ESM-only and not in the scaffolded transform list; @grafana/ui barrel imports it
 jest.mock('react-calendar', () => ({}));
 

--- a/src/views/QueryEditor/components/QueryTextEditor/components/Switches/StreamingSwitch.test.tsx
+++ b/src/views/QueryEditor/components/QueryTextEditor/components/Switches/StreamingSwitch.test.tsx
@@ -1,0 +1,22 @@
+jest.mock('react-calendar', () => ({}));
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { makeQuery } from 'spec/testUtils';
+import { StreamingSwitch } from './StreamingSwitch';
+
+describe('StreamingSwitch', () => {
+  it('reflects query.streaming state', () => {
+    render(<StreamingSwitch query={makeQuery({ streaming: true }) as any} onChange={jest.fn()} />);
+    expect(screen.getByTestId('streaming-switch')).toBeChecked();
+  });
+
+  it('fires onChange on click', () => {
+    const onChange = jest.fn();
+    render(<StreamingSwitch query={makeQuery({ streaming: false }) as any} onChange={onChange} />);
+    const sw = screen.getByTestId('streaming-switch');
+    expect(sw).not.toBeChecked();
+    fireEvent.click(sw);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/views/QueryEditor/components/QueryTextEditor/components/Switches/StreamingSwitch.test.tsx
+++ b/src/views/QueryEditor/components/QueryTextEditor/components/Switches/StreamingSwitch.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 jest.mock('react-calendar', () => ({}));
 
 import React from 'react';

--- a/src/views/QueryEditor/components/QueryTextEditor/hooks/useQueryHandlers.test.ts
+++ b/src/views/QueryEditor/components/QueryTextEditor/hooks/useQueryHandlers.test.ts
@@ -1,0 +1,32 @@
+import { useQueryHandlers } from './useQueryHandlers';
+
+// No React state inside the hook — a direct call is sufficient.
+const setup = () => {
+  const onFieldChange = jest.fn();
+  const handlers = useQueryHandlers({ onFieldChange, query: {} });
+  return { onFieldChange, handlers };
+};
+
+describe('useQueryHandlers streaming fallback defaults', () => {
+  it('streamingInterval uses || so 0 and undefined both fall back to 5000', () => {
+    const { onFieldChange, handlers } = setup();
+    handlers.handleStreamingIntervalChange(undefined);
+    handlers.handleStreamingIntervalChange(0);
+    handlers.handleStreamingIntervalChange(1000);
+    expect(onFieldChange.mock.calls.map((c) => c[0].value)).toEqual([5000, 5000, 1000]);
+  });
+
+  it('streamingLookback uses ?? so 0 is preserved and only undefined falls back to 1', () => {
+    const { onFieldChange, handlers } = setup();
+    handlers.handleStreamingLookbackChange(undefined);
+    handlers.handleStreamingLookbackChange(0);
+    expect(onFieldChange.mock.calls.map((c) => c[0].value)).toEqual([1, 0]);
+  });
+
+  it('streamingMode falls back to delta when undefined', () => {
+    const { onFieldChange, handlers } = setup();
+    handlers.handleStreamingModeChange(undefined);
+    handlers.handleStreamingModeChange('total');
+    expect(onFieldChange.mock.calls.map((c) => c[0].value)).toEqual(['delta', 'total']);
+  });
+});

--- a/src/views/QueryEditor/helpers/detectVariableMacroIntersections.test.ts
+++ b/src/views/QueryEditor/helpers/detectVariableMacroIntersections.test.ts
@@ -1,0 +1,47 @@
+import {
+  detectVariableMacroIntersections,
+  createVariableMacroConflictWarning,
+} from './detectVariableMacroIntersections';
+
+const mockTemplateSrv = { getVariables: jest.fn() };
+
+jest.mock('@grafana/runtime', () => ({
+  getTemplateSrv: () => mockTemplateSrv,
+}));
+
+describe('detectVariableMacroIntersections', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns [] when there are no variables', () => {
+    mockTemplateSrv.getVariables.mockReturnValue([]);
+    expect(detectVariableMacroIntersections()).toEqual([]);
+  });
+
+  it('detects a variable colliding with a macro ($ is prepended before compare)', () => {
+    mockTemplateSrv.getVariables.mockReturnValue([{ name: 'table' }, { name: 'rate' }]);
+    expect(detectVariableMacroIntersections()).toEqual(['$table', '$rate']);
+  });
+
+  it('ignores non-conflicting variables', () => {
+    mockTemplateSrv.getVariables.mockReturnValue([{ name: 'my_var' }, { name: 'env' }]);
+    expect(detectVariableMacroIntersections()).toEqual([]);
+  });
+});
+
+describe('createVariableMacroConflictWarning', () => {
+  it('returns empty string for no conflicts', () => {
+    expect(createVariableMacroConflictWarning([])).toBe('');
+  });
+
+  it('uses singular wording for one conflict', () => {
+    expect(createVariableMacroConflictWarning(['$table'])).toBe(
+      'Template variable "$table" has the same name as a ClickHouse macro. This may cause unexpected behavior during query processing.'
+    );
+  });
+
+  it('uses plural wording for several conflicts', () => {
+    expect(createVariableMacroConflictWarning(['$table', '$from'])).toBe(
+      'Template variables "$table, $from" have the same names as ClickHouse macros. This may cause unexpected behavior during query processing.'
+    );
+  });
+});

--- a/src/views/QueryEditor/helpers/initializeQueryDefaults.test.ts
+++ b/src/views/QueryEditor/helpers/initializeQueryDefaults.test.ts
@@ -1,0 +1,121 @@
+import { initializeQueryDefaults, initializeQueryDefaultsForVariables } from './initializeQueryDefaults';
+import { EditorMode, TimestampFormat } from '../../../types/types';
+import { DEFAULT_FORMAT, DEFAULT_ROUND, defaultQuery } from '../../constants';
+
+const noDefaults = {} as any;
+const withDefaults = (defaultValues: any = {}) => ({ defaultValues: { dateTime: {}, ...defaultValues } });
+
+describe.each([
+  ['initializeQueryDefaults', initializeQueryDefaults],
+  ['initializeQueryDefaultsForVariables', initializeQueryDefaultsForVariables],
+])('%s', (_name, init) => {
+  it('fills defaults for an empty query', () => {
+    const result = init({} as any, false, noDefaults, jest.fn());
+    expect(result).toMatchObject({
+      format: DEFAULT_FORMAT,
+      extrapolate: true,
+      skip_comments: true,
+      add_metadata: true,
+      nullifySparse: false,
+      useWindowFuncForMacros: true,
+      round: DEFAULT_ROUND,
+      intervalFactor: 1,
+      interval: '',
+      adHocFilters: [],
+      query: defaultQuery,
+      contextWindowSize: '10',
+      editorMode: EditorMode.Builder,
+      adHocValuesQuery: '',
+    });
+  });
+
+  it('infers editorMode: database+table -> SQL, explicit preserved, database only -> Builder', () => {
+    expect(init({ database: 'db', table: 't' } as any, false, noDefaults, jest.fn()).editorMode).toBe(EditorMode.SQL);
+    expect(
+      init({ database: 'db', table: 't', editorMode: EditorMode.Builder } as any, false, noDefaults, jest.fn())
+        .editorMode
+    ).toBe(EditorMode.Builder);
+    expect(init({ database: 'db' } as any, false, noDefaults, jest.fn()).editorMode).toBe(EditorMode.Builder);
+  });
+
+  it('preserves falsy-but-set values under ?? and replaces empty string under ||', () => {
+    const result = init({ extrapolate: false, format: '', round: '', query: '' } as any, false, noDefaults, jest.fn());
+    expect(result.extrapolate).toBe(false);
+    expect(result.format).toBe(DEFAULT_FORMAT);
+    expect(result.round).toBe('0s');
+    expect(result.query).not.toBe('');
+  });
+
+  it('does not call onChange without datasource.defaultValues', () => {
+    const onChange = jest.fn();
+    init({} as any, false, noDefaults, onChange);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('does not call onChange when query.initialized is true', () => {
+    const onChange = jest.fn();
+    init({ initialized: true } as any, false, withDefaults(), onChange);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('calls onChange exactly once with initialized: true', () => {
+    const onChange = jest.fn();
+    init({} as any, false, withDefaults(), onChange);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ initialized: true }));
+  });
+
+  it('applies defaultDateTimeType only when query has none', () => {
+    const ds = withDefaults({ defaultDateTimeType: TimestampFormat.DateTime64 });
+    expect(init({} as any, false, ds, jest.fn()).dateTimeType).toBe(TimestampFormat.DateTime64);
+    expect(init({ dateTimeType: TimestampFormat.Float } as any, false, ds, jest.fn()).dateTimeType).toBe(
+      TimestampFormat.Float
+    );
+  });
+
+  const colCases: Array<[string, string]> = [
+    [TimestampFormat.DateTime, 'defaultDateTime'],
+    [TimestampFormat.DateTime64, 'defaultDateTime64'],
+    [TimestampFormat.TimeStamp, 'defaultUint32'],
+    [TimestampFormat.Float, 'defaultFloat'],
+    [TimestampFormat.TimeStamp64_3, 'defaultTimeStamp64_3'],
+    [TimestampFormat.TimeStamp64_6, 'defaultTimeStamp64_6'],
+    [TimestampFormat.TimeStamp64_9, 'defaultTimeStamp64_9'],
+  ];
+
+  it.each(colCases)('dateTimeColDataType default for %s', (type, field) => {
+    const ds = withDefaults({ dateTime: { [field]: 'default_col' } });
+    // applied when dateTimeType matches
+    expect(init({ dateTimeType: type } as any, false, ds, jest.fn()).dateTimeColDataType).toBe('default_col');
+    // not applied on a mismatched type
+    const other = type === TimestampFormat.Float ? TimestampFormat.DateTime : TimestampFormat.Float;
+    expect(init({ dateTimeType: other } as any, false, ds, jest.fn()).dateTimeColDataType).toBeUndefined();
+    // existing value not overwritten
+    expect(
+      init({ dateTimeType: type, dateTimeColDataType: 'mine' } as any, false, ds, jest.fn()).dateTimeColDataType
+    ).toBe('mine');
+  });
+
+  it('applies defaultDateDate32 only when query has no dateColDataType', () => {
+    const ds = withDefaults({ dateTime: { defaultDateDate32: 'event_date' } });
+    expect(init({} as any, false, ds, jest.fn()).dateColDataType).toBe('event_date');
+    expect(init({ dateColDataType: 'mine' } as any, false, ds, jest.fn()).dateColDataType).toBe('mine');
+  });
+
+  it('applies datasource contextWindowSize only when query has none (check reads query, not the "10" default)', () => {
+    const ds = withDefaults({ contextWindowSize: '25' });
+    expect(init({} as any, false, ds, jest.fn()).contextWindowSize).toBe('25');
+    expect(init({ contextWindowSize: '5' } as any, false, ds, jest.fn()).contextWindowSize).toBe('5');
+  });
+
+  it('datasource nullifySparse overrides the earlier false default when query has it undefined', () => {
+    const ds = withDefaults({ nullifySparse: true });
+    expect(init({} as any, false, ds, jest.fn()).nullifySparse).toBe(true);
+    expect(init({ nullifySparse: false } as any, false, ds, jest.fn()).nullifySparse).toBe(false);
+  });
+
+  it('isAnnotationView forces format ANNOTATION', () => {
+    expect(init({} as any, true, noDefaults, jest.fn()).format).toBe('ANNOTATION');
+    expect(init({ format: 'table' } as any, true, withDefaults(), jest.fn()).format).toBe('ANNOTATION');
+  });
+});

--- a/src/views/QueryEditor/hooks/useFormattedData.test.ts
+++ b/src/views/QueryEditor/hooks/useFormattedData.test.ts
@@ -1,0 +1,66 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useFormattedData } from './useFormattedData';
+
+jest.mock('./useSystemDatabases', () => ({ useSystemDatabases: jest.fn().mockReturnValue(null) }));
+jest.mock('./useAutocompletionData', () => ({
+  useAutocompleteData: jest.fn().mockReturnValue({ data: null, hasPermissionError: false }),
+}));
+
+const query = { query: 'SELECT $x' } as any;
+
+const makeDatasource = (overrides: any = {}) =>
+  ({
+    name: 'ds',
+    templateSrv: {},
+    options: { range: { from: 1, to: 2 } },
+    replace: jest.fn().mockResolvedValue({ stmt: 'SELECT replaced' }),
+    ...overrides,
+  } as any);
+
+describe('useFormattedData', () => {
+  it('replaces the query when range and templateSrv are available', async () => {
+    const ds = makeDatasource();
+    const { result } = renderHook(() => useFormattedData(query, ds));
+    await waitFor(() => expect(result.current[0]).toBe('SELECT replaced'));
+    expect(result.current[1]).toBeNull();
+    expect(ds.replace).toHaveBeenCalledWith(ds.options, query);
+  });
+
+  it('falls back to the raw query with the error text on structured replace failure', async () => {
+    const ds = makeDatasource({ replace: jest.fn().mockRejectedValue({ data: { error: 'x' } }) });
+    const { result } = renderHook(() => useFormattedData(query, ds));
+    await waitFor(() => expect(result.current[1]).toBe('x'));
+    expect(result.current[0]).toBe('SELECT $x');
+  });
+
+  it('stringifies plain errors from replace', async () => {
+    const ds = makeDatasource({ replace: jest.fn().mockRejectedValue(new Error('bad')) });
+    const { result } = renderHook(() => useFormattedData(query, ds));
+    await waitFor(() => expect(result.current[1]).toBe('Error: bad'));
+  });
+
+  it('passes the query through without error when there is no execution context', async () => {
+    const ds = makeDatasource({ options: undefined });
+    const { result } = renderHook(() => useFormattedData(query, ds));
+    await waitFor(() => expect(result.current[0]).toBe('SELECT $x'));
+    expect(result.current[1]).toBeNull();
+    expect(ds.replace).not.toHaveBeenCalled();
+  });
+
+  it('reports a critical error when templateSrv is missing', async () => {
+    const ds = makeDatasource({ templateSrv: undefined });
+    const { result } = renderHook(() => useFormattedData(query, ds));
+    await waitFor(() =>
+      expect(result.current[1]).toBe('Grafana template service unavailable. Please refresh the page.')
+    );
+    expect(result.current[0]).toBe('SELECT $x');
+  });
+
+  it('takes the range from the options argument when the datasource has none', async () => {
+    const ds = makeDatasource({ options: undefined });
+    const options = { range: { from: 1, to: 2 } };
+    const { result } = renderHook(() => useFormattedData(query, ds, options));
+    await waitFor(() => expect(result.current[0]).toBe('SELECT replaced'));
+    expect(ds.replace).toHaveBeenCalledWith(options, query);
+  });
+});

--- a/src/views/QueryEditor/hooks/useQueryState.test.ts
+++ b/src/views/QueryEditor/hooks/useQueryState.test.ts
@@ -1,0 +1,94 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useQueryState } from './useQueryState';
+import { IndexedDBManager } from '../../../utils/indexedDBManager';
+import { DEFAULT_FORMAT, defaultQuery } from '../../constants';
+
+jest.mock('../../../utils/indexedDBManager', () => ({
+  IndexedDBManager: {
+    getItem: jest.fn().mockResolvedValue(null),
+    setItem: jest.fn().mockResolvedValue(undefined),
+    limitQueryStatesPerDatasource: jest.fn().mockResolvedValue(0),
+  },
+}));
+
+const mocked = IndexedDBManager as jest.Mocked<typeof IndexedDBManager>;
+const datasource = { name: 'ds', uid: 'uid1' };
+const accessKey = 'dataStorage_ds_uid1_A';
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe('useQueryState', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mocked.getItem.mockResolvedValue(null);
+    mocked.setItem.mockResolvedValue(undefined);
+    mocked.limitQueryStatesPerDatasource.mockResolvedValue(0);
+  });
+
+  const render = (query: any = { refId: 'A', query: 'SELECT 1' }, onChange = jest.fn()) => ({
+    onChange,
+    ...renderHook(() => useQueryState(query, onChange, datasource)),
+  });
+
+  it('does not call onChange when nothing is stored, but still limits query states', async () => {
+    const { onChange } = render();
+    await waitFor(() => expect(mocked.limitQueryStatesPerDatasource).toHaveBeenCalledWith('uid1'));
+    expect(mocked.getItem).toHaveBeenCalledWith(accessKey);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('resets the query when a fresh record from another panel is found', async () => {
+    mocked.getItem.mockResolvedValue({ name: 'dataStorage_other', timestamp: Date.now() });
+    const { onChange } = render({ refId: 'A', query: 'SELECT 1', database: 'db', table: 't' });
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+    const reset = onChange.mock.calls[0][0];
+    expect(reset.format).toBe(DEFAULT_FORMAT);
+    expect(reset.query).toBe(defaultQuery);
+    expect(reset.formattedQuery).toBe('SELECT 1');
+    expect(reset.database).toBeUndefined();
+    expect(reset.table).toBeUndefined();
+    expect(reset.dateColDataType).toBeUndefined();
+    expect(reset.dateTimeColDataType).toBeUndefined();
+  });
+
+  it('does not reset when the stored name matches the own access key', async () => {
+    mocked.getItem.mockResolvedValue({ name: accessKey, timestamp: Date.now() });
+    const { onChange } = render();
+    await waitFor(() => expect(mocked.limitQueryStatesPerDatasource).toHaveBeenCalled());
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('does not reset when the stored record is older than 5 seconds', async () => {
+    mocked.getItem.mockResolvedValue({ name: 'dataStorage_other', timestamp: Date.now() - 6000 });
+    const { onChange } = render();
+    await waitFor(() => expect(mocked.limitQueryStatesPerDatasource).toHaveBeenCalled());
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('stores its state and re-limits on unmount, swallowing rejections', async () => {
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { unmount } = render();
+    await waitFor(() => expect(mocked.limitQueryStatesPerDatasource).toHaveBeenCalledTimes(1));
+
+    mocked.setItem.mockRejectedValue(new Error('quota'));
+    mocked.limitQueryStatesPerDatasource.mockRejectedValue(new Error('limit'));
+    unmount();
+
+    expect(mocked.setItem).toHaveBeenCalledWith(accessKey, { name: accessKey, timestamp: expect.any(Number) }, 60);
+    expect(mocked.limitQueryStatesPerDatasource).toHaveBeenCalledTimes(2);
+    await flush();
+    expect(error).toHaveBeenCalledWith('Failed to store query state on unmount:', expect.any(Error));
+    expect(error).toHaveBeenCalledWith('Failed to limit query states on unmount:', expect.any(Error));
+    error.mockRestore();
+  });
+
+  it('logs and survives a getItem failure', async () => {
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mocked.getItem.mockRejectedValue(new Error('idb down'));
+    const { onChange } = render();
+    await waitFor(() =>
+      expect(error).toHaveBeenCalledWith('Failed to initialize query state:', expect.any(Error))
+    );
+    expect(onChange).not.toHaveBeenCalled();
+    error.mockRestore();
+  });
+});

--- a/src/views/QueryEditor/hooks/useSystemDatabases.test.ts
+++ b/src/views/QueryEditor/hooks/useSystemDatabases.test.ts
@@ -1,0 +1,73 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useSystemDatabases } from './useSystemDatabases';
+import { IndexedDBManager } from '../../../utils/indexedDBManager';
+
+jest.mock('../../../utils/indexedDBManager', () => ({
+  IndexedDBManager: {
+    getItem: jest.fn().mockResolvedValue(null),
+    setItem: jest.fn().mockResolvedValue(undefined),
+    cleanupExpiredByPrefix: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+const mocked = IndexedDBManager as jest.Mocked<typeof IndexedDBManager>;
+
+describe('useSystemDatabases', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mocked.getItem.mockResolvedValue(null);
+    mocked.setItem.mockResolvedValue(undefined);
+    mocked.cleanupExpiredByPrefix.mockResolvedValue(undefined as any);
+  });
+
+  it('returns cached data without querying the datasource', async () => {
+    mocked.getItem.mockResolvedValue(['a', 'b']);
+    const datasource = { uid: 'uid1', metricFindQuery: jest.fn() };
+    const { result } = renderHook(() => useSystemDatabases(datasource));
+    await waitFor(() => expect(result.current).toEqual(['a', 'b']));
+    expect(datasource.metricFindQuery).not.toHaveBeenCalled();
+  });
+
+  it('queries on cache miss, maps to text and caches with a 10 minute TTL', async () => {
+    const datasource = {
+      uid: 'uid1',
+      metricFindQuery: jest.fn().mockResolvedValue([{ text: 'functions' }, { text: 'tables' }]),
+    };
+    const { result } = renderHook(() => useSystemDatabases(datasource));
+    await waitFor(() => expect(result.current).toEqual(['functions', 'tables']));
+    expect(mocked.setItem).toHaveBeenCalledWith('altinity_systemDatabases_uid1', ['functions', 'tables'], 10);
+  });
+
+  it('caches an empty result on permission error and logs via console.info', async () => {
+    const info = jest.spyOn(console, 'info').mockImplementation(() => {});
+    const datasource = {
+      uid: 'uid1',
+      metricFindQuery: jest.fn().mockRejectedValue({ status: 497, message: 'ACCESS_DENIED' }),
+    };
+    const { result } = renderHook(() => useSystemDatabases(datasource));
+    await waitFor(() => expect(result.current).toEqual([]));
+    expect(mocked.setItem).toHaveBeenCalledWith('altinity_systemDatabases_uid1', [], 10);
+    expect(info).toHaveBeenCalledWith(expect.stringContaining('uid1'));
+    info.mockRestore();
+  });
+
+  it('returns [] on generic errors without caching', async () => {
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const datasource = { uid: 'uid1', metricFindQuery: jest.fn().mockRejectedValue(new Error('boom')) };
+    const { result } = renderHook(() => useSystemDatabases(datasource));
+    await waitFor(() => expect(result.current).toEqual([]));
+    expect(mocked.setItem).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith('Failed to fetch system databases:', expect.any(Error));
+    error.mockRestore();
+  });
+
+  it('swallows cleanup failures and still fetches', async () => {
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mocked.cleanupExpiredByPrefix.mockRejectedValue(new Error('cleanup failed'));
+    const datasource = { uid: 'uid1', metricFindQuery: jest.fn().mockResolvedValue([{ text: 'db' }]) };
+    const { result } = renderHook(() => useSystemDatabases(datasource));
+    await waitFor(() => expect(result.current).toEqual(['db']));
+    expect(error).toHaveBeenCalledWith('Failed to cleanup expired system databases data:', expect.any(Error));
+    error.mockRestore();
+  });
+});


### PR DESCRIPTION
Part of the coverage improvement effort: raise unit test coverage from the weakest spots up to ~90% on both sides.

## Backend (Go): 56.3% -> 91.7%
- `resource_handlers.go` 0% -> 92% — all 7 handlers through real `CallResource` routing, malformed bodies, error branches
- `parser.go` -> 100%, `query.go` -> 100%, `timeutils` + `requests` -> 100%
- `streaming.go` 59% -> 94% (mergeFramesToWide, dedup, delta loop via stubbed ClickHouse)
- `datasource.go` 27% -> 87%, `client.go` 47% -> 92% (compression gzip/deflate/zstd/br, auth variants, error paths via httptest)
- `response.go` -> 96%, `eval` -> 90%

## Frontend (Jest): 39.3% -> 91.9%
- `datasource.ts` 22% -> 97%, `adhoc.ts` -> 99%, `indexedDBManager.ts` 3% -> 92% (via fake-indexeddb, new dev dep)
- All QueryEditor hooks/helpers 0% -> ~100% (renderHook)
- RTL tests for ConfigEditor/QueryEditor/QueryBuilder/QueryHeader/FormParts/streaming controls
- Coverage ratchet raised in jest.config.js: stmts 32 -> 90, branches 31 -> 88, funcs 21 -> 80, lines 32 -> 90

663 frontend tests (was 310), ~350 new Go cases. Skipped intentionally: Monaco wiring (SQLCodeEditor/initiateEditor), main(), unreachable branches.

## Latent bugs found while writing tests (documented, not fixed here)
1. `src/datasource/adhoc.ts:75` — `.combine()` called on a plain array -> TypeError on duplicate Enum column names
2. `src/datasource/datasource.ts:283-300` — dead `traceId` branch in getLogRowContext
3. `pkg/eval/eval_query.go:2332` — PrintAST panics on `$lttbMs` (reads `AST.Obj["$lttb"]`)
4. `pkg/parser.go` — off-by-one in `extractTimeZoneNameFromFieldType`: `DateTime('UTC')` extracts `"TC"`, silently falls back to server TZ
5. `UniversalSelectField` — infinite re-render when `value` is empty (effect resets state with a fresh array each run)